### PR TITLE
Make nfs3_client operations work with default tokio scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,6 @@ dependencies = [
 name = "nfs3_client"
 version = "0.3.0"
 dependencies = [
- "async-trait",
  "chrono",
  "nfs3_types",
  "rand",

--- a/crates/nfs3_client/Cargo.toml
+++ b/crates/nfs3_client/Cargo.toml
@@ -16,7 +16,6 @@ tokio = ["dep:tokio"]
 [dependencies]
 nfs3_types = { path = "../nfs3_types", version = "0.3.1" }
 
-async-trait.workspace = true
 rand.workspace = true
 tokio = { workspace = true, optional = true, default-features = false, features = ["net", "io-util"] }
 

--- a/crates/nfs3_client/src/connect.rs
+++ b/crates/nfs3_client/src/connect.rs
@@ -25,7 +25,7 @@ pub struct Nfs3Connection<IO> {
 
 impl<IO> Nfs3Connection<IO>
 where
-    IO: AsyncRead + AsyncWrite,
+    IO: AsyncRead + AsyncWrite + Send,
 {
     /// Returns the root file handle of the mounted filesystem.
     pub fn root_nfs_fh3(&self) -> nfs_fh3 {
@@ -80,7 +80,7 @@ pub struct Nfs3ConnectionBuilder<C> {
 impl<C, S> Nfs3ConnectionBuilder<C>
 where
     C: crate::net::Connector<Connection = S>,
-    S: AsyncRead + AsyncWrite + 'static,
+    S: AsyncRead + AsyncWrite + Send,
 {
     /// Creates a new `NFSv3` connection builder.
     /// The `mount_path` is the path to mount on the server.

--- a/crates/nfs3_client/src/io.rs
+++ b/crates/nfs3_client/src/io.rs
@@ -1,7 +1,7 @@
 //! Asynchronous I/O traits for reading and writing bytes.
 
 /// Trait to read bytes asynchronously.
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait AsyncRead {
     /// Read bytes from the stream into the provided buffer.
     async fn async_read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>;
@@ -18,7 +18,7 @@ pub trait AsyncRead {
 }
 
 /// Trait to write bytes asynchronously.
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait AsyncWrite {
     /// Write bytes to the stream from the provided buffer.
     async fn async_write(&mut self, buf: &[u8]) -> std::io::Result<usize>;

--- a/crates/nfs3_client/src/io.rs
+++ b/crates/nfs3_client/src/io.rs
@@ -1,35 +1,41 @@
 //! Asynchronous I/O traits for reading and writing bytes.
 
 /// Trait to read bytes asynchronously.
-#[async_trait::async_trait]
-pub trait AsyncRead {
+pub trait AsyncRead: Send {
     /// Read bytes from the stream into the provided buffer.
-    async fn async_read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>;
+    fn async_read(&mut self, buf: &mut [u8])
+    -> impl Future<Output = std::io::Result<usize>> + Send;
 
     /// Read exactly the number of bytes into the buffer.
-    async fn async_read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
-        let mut buf = buf;
-        while !buf.is_empty() {
-            let n = self.async_read(buf).await?;
-            buf = &mut buf[n..];
+    fn async_read_exact(
+        &mut self,
+        buf: &mut [u8],
+    ) -> impl Future<Output = std::io::Result<()>> + Send {
+        async move {
+            let mut buf = buf;
+            while !buf.is_empty() {
+                let n = self.async_read(buf).await?;
+                buf = &mut buf[n..];
+            }
+            Ok(())
         }
-        Ok(())
     }
 }
 
 /// Trait to write bytes asynchronously.
-#[async_trait::async_trait]
-pub trait AsyncWrite {
+pub trait AsyncWrite: Send {
     /// Write bytes to the stream from the provided buffer.
-    async fn async_write(&mut self, buf: &[u8]) -> std::io::Result<usize>;
+    fn async_write(&mut self, buf: &[u8]) -> impl Future<Output = std::io::Result<usize>> + Send;
 
     /// Write all bytes to the stream from the provided buffer.
-    async fn async_write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
-        let mut buf = buf;
-        while !buf.is_empty() {
-            let n = self.async_write(buf).await?;
-            buf = &buf[n..];
+    fn async_write_all(&mut self, buf: &[u8]) -> impl Future<Output = std::io::Result<()>> + Send {
+        async move {
+            let mut buf = buf;
+            while !buf.is_empty() {
+                let n = self.async_write(buf).await?;
+                buf = &buf[n..];
+            }
+            Ok(())
         }
-        Ok(())
     }
 }

--- a/crates/nfs3_client/src/mount.rs
+++ b/crates/nfs3_client/src/mount.rs
@@ -18,7 +18,7 @@ pub struct MountClient<IO> {
 
 impl<IO> MountClient<IO>
 where
-    IO: AsyncRead + AsyncWrite,
+    IO: AsyncRead + AsyncWrite + Send,
 {
     /// Create a new mount client.
     pub fn new(io: IO) -> Self {

--- a/crates/nfs3_client/src/net.rs
+++ b/crates/nfs3_client/src/net.rs
@@ -3,9 +3,9 @@
 use crate::io::{AsyncRead, AsyncWrite};
 
 /// Trait for connecting to a host and port.
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait Connector {
-    type Connection: AsyncRead + AsyncWrite;
+    type Connection: AsyncRead + AsyncWrite + Send;
 
     /// Connect to a host and port.
     async fn connect(&self, host: &str, port: u16) -> std::io::Result<Self::Connection>;

--- a/crates/nfs3_client/src/net.rs
+++ b/crates/nfs3_client/src/net.rs
@@ -3,20 +3,23 @@
 use crate::io::{AsyncRead, AsyncWrite};
 
 /// Trait for connecting to a host and port.
-#[async_trait::async_trait]
-pub trait Connector {
+pub trait Connector: Send {
     type Connection: AsyncRead + AsyncWrite + Send;
 
     /// Connect to a host and port.
-    async fn connect(&self, host: &str, port: u16) -> std::io::Result<Self::Connection>;
+    fn connect(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> impl Future<Output = std::io::Result<Self::Connection>> + Send;
 
     /// Many NFS servers, especially on Linux, require that the source port used for NFS
     /// communication be in the privileged range (0-1023) by default.
     /// When the `local_port` is already in use, the function should return `AddrInUse` error.
-    async fn connect_with_port(
+    fn connect_with_port(
         &self,
         host: &str,
         port: u16,
         local_port: u16,
-    ) -> std::io::Result<Self::Connection>;
+    ) -> impl Future<Output = std::io::Result<Self::Connection>> + Send;
 }

--- a/crates/nfs3_client/src/nfs.rs
+++ b/crates/nfs3_client/src/nfs.rs
@@ -24,7 +24,7 @@ pub struct Nfs3Client<IO> {
 
 impl<IO> Nfs3Client<IO>
 where
-    IO: AsyncRead + AsyncWrite,
+    IO: AsyncRead + AsyncWrite + Send,
 {
     /// Create a new `NFSv3` client.
     pub fn new(io: IO) -> Self {

--- a/crates/nfs3_client/src/portmapper.rs
+++ b/crates/nfs3_client/src/portmapper.rs
@@ -14,7 +14,7 @@ pub struct PortmapperClient<IO> {
 
 impl<IO> PortmapperClient<IO>
 where
-    IO: AsyncRead + AsyncWrite,
+    IO: AsyncRead + AsyncWrite + Send,
 {
     pub fn new(io: IO) -> Self {
         Self {

--- a/crates/nfs3_client/src/rpc.rs
+++ b/crates/nfs3_client/src/rpc.rs
@@ -28,7 +28,7 @@ impl<IO> Debug for RpcClient<IO> {
 
 impl<IO> RpcClient<IO>
 where
-    IO: AsyncRead + AsyncWrite,
+    IO: AsyncRead + AsyncWrite + Send,
 {
     /// Create a new RPC client. XID is initialized to a random value.
     pub fn new(io: IO) -> Self {

--- a/crates/nfs3_client/src/tokio.rs
+++ b/crates/nfs3_client/src/tokio.rs
@@ -20,7 +20,6 @@ impl<T> TokioIo<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T> AsyncRead for TokioIo<T>
 where
     T: TokioAsyncRead + Unpin + Send,
@@ -30,7 +29,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T> AsyncWrite for TokioIo<T>
 where
     T: TokioAsyncWrite + Unpin + Send,
@@ -45,7 +43,6 @@ where
 /// Connects to a host and port using Tokio's [`TcpStream`].
 pub struct TokioConnector;
 
-#[async_trait::async_trait]
 impl Connector for TokioConnector {
     type Connection = TokioIo<TcpStream>;
 

--- a/crates/nfs3_client/src/tokio.rs
+++ b/crates/nfs3_client/src/tokio.rs
@@ -20,20 +20,20 @@ impl<T> TokioIo<T> {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl<T> AsyncRead for TokioIo<T>
 where
-    T: TokioAsyncRead + Unpin,
+    T: TokioAsyncRead + Unpin + Send,
 {
     async fn async_read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         tokio::io::AsyncReadExt::read(&mut self.0, buf).await
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl<T> AsyncWrite for TokioIo<T>
 where
-    T: TokioAsyncWrite + Unpin,
+    T: TokioAsyncWrite + Unpin + Send,
 {
     async fn async_write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         tokio::io::AsyncWriteExt::write(&mut self.0, buf).await
@@ -45,7 +45,7 @@ where
 /// Connects to a host and port using Tokio's [`TcpStream`].
 pub struct TokioConnector;
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Connector for TokioConnector {
     type Connection = TokioIo<TcpStream>;
 


### PR DESCRIPTION
The default tokio scheduler is multi-threaded and work-stealing. Therefore, the futures returned by async operations need to be Send in order to execute them from within tokio::spawn() on the default scheduler.

This change removes #[async_trait] as, I believe that results in a Pin<Box<Future>> which could have performance implications (and the rest of the code doesn't use these traits as dyn anyway).