### PR TITLE
feat!: add FileHandle trait

### DIFF
--- a/crates/nfs3_server/src/context.rs
+++ b/crates/nfs3_server/src/context.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::sync::Arc;
+use crate::vfs::handle::FileHandleConverter;
 
 use nfs3_types::rpc::auth_unix;
 use tokio::sync::mpsc;
@@ -14,6 +15,7 @@ pub struct RPCContext<T> {
     pub mount_signal: Option<mpsc::Sender<bool>>,
     pub export_name: Arc<String>,
     pub transaction_tracker: Arc<TransactionTracker>,
+    pub file_handle_converter: FileHandleConverter,
 }
 
 #[allow(clippy::missing_fields_in_debug)]
@@ -40,6 +42,7 @@ impl<T> Clone for RPCContext<T> {
             mount_signal: self.mount_signal.clone(),
             export_name: Arc::clone(&self.export_name),
             transaction_tracker: Arc::clone(&self.transaction_tracker),
+            file_handle_converter: self.file_handle_converter.clone(),
         }
     }
 }

--- a/crates/nfs3_server/src/context.rs
+++ b/crates/nfs3_server/src/context.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 use std::sync::Arc;
-use crate::vfs::handle::FileHandleConverter;
 
 use nfs3_types::rpc::auth_unix;
 use tokio::sync::mpsc;
 
 use crate::transaction_tracker::TransactionTracker;
+use crate::vfs::handle::FileHandleConverter;
 
 pub struct RPCContext<T> {
     pub local_port: u16,
@@ -15,7 +15,7 @@ pub struct RPCContext<T> {
     pub mount_signal: Option<mpsc::Sender<bool>>,
     pub export_name: Arc<String>,
     pub transaction_tracker: Arc<TransactionTracker>,
-    pub file_handle_converter: FileHandleConverter,
+    pub(crate) file_handle_converter: FileHandleConverter,
 }
 
 #[allow(clippy::missing_fields_in_debug)]
@@ -44,5 +44,32 @@ impl<T> Clone for RPCContext<T> {
             transaction_tracker: Arc::clone(&self.transaction_tracker),
             file_handle_converter: self.file_handle_converter.clone(),
         }
+    }
+}
+
+#[doc(hidden)]
+#[cfg(feature = "__test_reexports")]
+impl<T> RPCContext<T>
+where
+    T: crate::vfs::NfsFileSystem + 'static,
+{
+    pub fn test_ctx(export_name: &str, vfs: Arc<T>) -> Self {
+        Self {
+            local_port: 2049,
+            client_addr: "localhost".to_owned(),
+            auth: auth_unix::default(),
+            vfs,
+            mount_signal: None,
+            export_name: Arc::new(export_name.to_owned()),
+            transaction_tracker: Arc::new(TransactionTracker::new(
+                std::time::Duration::from_secs(60),
+                256,
+                1024,
+            )),
+            file_handle_converter: FileHandleConverter::new(),
+        }
+    }
+    pub fn root_dir(&self) -> nfs3_types::nfs3::nfs_fh3 {
+        self.file_handle_converter.fh_to_nfs(&self.vfs.root_dir())
     }
 }

--- a/crates/nfs3_server/src/context.rs
+++ b/crates/nfs3_server/src/context.rs
@@ -42,7 +42,7 @@ impl<T> Clone for RPCContext<T> {
             mount_signal: self.mount_signal.clone(),
             export_name: Arc::clone(&self.export_name),
             transaction_tracker: Arc::clone(&self.transaction_tracker),
-            file_handle_converter: self.file_handle_converter.clone(),
+            file_handle_converter: self.file_handle_converter,
         }
     }
 }
@@ -69,6 +69,7 @@ where
             file_handle_converter: FileHandleConverter::new(),
         }
     }
+    #[must_use]
     pub fn root_dir(&self) -> nfs3_types::nfs3::nfs_fh3 {
         self.file_handle_converter.fh_to_nfs(&self.vfs.root_dir())
     }

--- a/crates/nfs3_server/src/memfs.rs
+++ b/crates/nfs3_server/src/memfs.rs
@@ -40,11 +40,27 @@ use nfs3_types::nfs3::{
 use nfs3_types::xdr_codec::Opaque;
 
 use crate::vfs::{
-    DEFAULT_FH_CONVERTER, NextResult, NfsFileSystem, NfsReadFileSystem, ReadDirIterator,
-    ReadDirPlusIterator,
+    DEFAULT_FH_CONVERTER, FileHandle, NextResult, NfsFileSystem, NfsReadFileSystem,
+    ReadDirIterator, ReadDirPlusIterator,
 };
 
 const DELIMITER: char = '/';
+
+pub struct MemFsHandle {
+    id: [u8; 8],
+}
+
+impl FileHandle for MemFsHandle {
+    fn len(&self) -> usize {
+        self.id.len()
+    }
+    fn as_bytes(&self) -> &[u8] {
+        &self.id
+    }
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytes.try_into().ok().map(|id| Self { id })
+    }
+}
 
 #[derive(Debug)]
 struct Dir {
@@ -525,6 +541,8 @@ impl MemFs {
 }
 
 impl NfsReadFileSystem for MemFs {
+    type Handle = MemFsHandle;
+
     fn root_dir(&self) -> fileid3 {
         self.rootdir
     }

--- a/crates/nfs3_server/src/memfs.rs
+++ b/crates/nfs3_server/src/memfs.rs
@@ -34,13 +34,14 @@ use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
 use nfs3_types::nfs3::{
-    self as nfs, cookie3, entryplus3, fattr3, filename3, ftype3, nfspath3,
-    nfsstat3, nfstime3, sattr3, specdata3,
+    self as nfs, cookie3, entryplus3, fattr3, filename3, ftype3, nfspath3, nfsstat3, nfstime3,
+    sattr3, specdata3,
 };
 use nfs3_types::xdr_codec::Opaque;
 
 use crate::vfs::{
-    FileHandleU64, NextResult, NfsFileSystem, NfsReadFileSystem, ReadDirIterator, ReadDirPlusIterator
+    FileHandleU64, NextResult, NfsFileSystem, NfsReadFileSystem, ReadDirIterator,
+    ReadDirPlusIterator,
 };
 
 const DELIMITER: char = '/';
@@ -99,7 +100,12 @@ struct File {
 }
 
 impl File {
-    fn new(name: filename3<'static>, id: FileHandleU64, parent: FileHandleU64, content: Vec<u8>) -> Self {
+    fn new(
+        name: filename3<'static>,
+        id: FileHandleU64,
+        parent: FileHandleU64,
+        content: Vec<u8>,
+    ) -> Self {
         let current_time = current_time();
         let attr = fattr3 {
             type_: ftype3::NF3REG,
@@ -178,7 +184,12 @@ enum Entry {
 }
 
 impl Entry {
-    fn new_file(name: filename3<'static>, id: FileHandleU64, parent: FileHandleU64, content: Vec<u8>) -> Self {
+    fn new_file(
+        name: filename3<'static>,
+        id: FileHandleU64,
+        parent: FileHandleU64,
+        content: Vec<u8>,
+    ) -> Self {
         Self::File(File::new(name, id, parent, content))
     }
 
@@ -218,7 +229,8 @@ impl Entry {
         match self {
             Self::File(file) => file.attr.fileid,
             Self::Dir(dir) => dir.attr.fileid,
-        }.into()
+        }
+        .into()
     }
 
     const fn name(&self) -> &filename3<'static> {
@@ -463,7 +475,11 @@ impl MemFs {
         Ok((newid, attr))
     }
 
-    fn lookup_impl(&self, dirid: &FileHandleU64, filename: &filename3) -> Result<FileHandleU64, nfsstat3> {
+    fn lookup_impl(
+        &self,
+        dirid: &FileHandleU64,
+        filename: &filename3,
+    ) -> Result<FileHandleU64, nfsstat3> {
         let fs = self.fs.read().expect("lock is poisoned");
         let entry = fs.get(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
 
@@ -507,10 +523,14 @@ impl MemFs {
         Ok(fid)
     }
 
-    fn make_iter(&self, dirid: &FileHandleU64, start_after: cookie3) -> Result<MemFsIterator, nfsstat3> {
+    fn make_iter(
+        &self,
+        dirid: &FileHandleU64,
+        start_after: cookie3,
+    ) -> Result<MemFsIterator, nfsstat3> {
         let fs = self.fs.read().expect("lock is poisoned");
         let entry = fs.get(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let dir = entry.as_dir()?;        
+        let dir = entry.as_dir()?;
 
         let mut iter = dir.content.iter();
         if start_after != 0 {
@@ -532,7 +552,11 @@ impl NfsReadFileSystem for MemFs {
         self.rootdir
     }
 
-    async fn lookup(&self, dirid: &FileHandleU64, filename: &filename3<'_>) -> Result<FileHandleU64, nfsstat3> {
+    async fn lookup(
+        &self,
+        dirid: &FileHandleU64,
+        filename: &filename3<'_>,
+    ) -> Result<FileHandleU64, nfsstat3> {
         self.lookup_impl(dirid, filename)
     }
 
@@ -598,7 +622,12 @@ impl NfsFileSystem for MemFs {
         Ok(entry.attr().clone())
     }
 
-    async fn write(&self, id: &FileHandleU64, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+    async fn write(
+        &self,
+        id: &FileHandleU64,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<fattr3, nfsstat3> {
         let mut fs = self.fs.write().expect("lock is poisoned");
 
         let entry = fs.get_mut(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
@@ -632,7 +661,11 @@ impl NfsFileSystem for MemFs {
         self.add_dir(dirid, dirname.clone_to_owned())
     }
 
-    async fn remove(&self, dirid: &FileHandleU64, filename: &filename3<'_>) -> Result<(), nfsstat3> {
+    async fn remove(
+        &self,
+        dirid: &FileHandleU64,
+        filename: &filename3<'_>,
+    ) -> Result<(), nfsstat3> {
         self.fs
             .write()
             .expect("lock is poisoned")

--- a/crates/nfs3_server/src/memfs.rs
+++ b/crates/nfs3_server/src/memfs.rs
@@ -582,7 +582,7 @@ impl NfsReadFileSystem for MemFs {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
-    async fn path_to_id(&self, path: &str) -> Result<fileid3, nfsstat3> {
+    async fn lookup_by_path(&self, path: &str) -> Result<fileid3, nfsstat3> {
         self.path_to_id_impl(path)
     }
 }

--- a/crates/nfs3_server/src/memfs.rs
+++ b/crates/nfs3_server/src/memfs.rs
@@ -34,44 +34,27 @@ use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
 use nfs3_types::nfs3::{
-    self as nfs, cookie3, entryplus3, fattr3, fileid3, filename3, ftype3, nfs_fh3, nfspath3,
+    self as nfs, cookie3, entryplus3, fattr3, filename3, ftype3, nfspath3,
     nfsstat3, nfstime3, sattr3, specdata3,
 };
 use nfs3_types::xdr_codec::Opaque;
 
 use crate::vfs::{
-    DEFAULT_FH_CONVERTER, FileHandle, NextResult, NfsFileSystem, NfsReadFileSystem,
-    ReadDirIterator, ReadDirPlusIterator,
+    FileHandleU64, NextResult, NfsFileSystem, NfsReadFileSystem, ReadDirIterator, ReadDirPlusIterator
 };
 
 const DELIMITER: char = '/';
 
-pub struct MemFsHandle {
-    id: [u8; 8],
-}
-
-impl FileHandle for MemFsHandle {
-    fn len(&self) -> usize {
-        self.id.len()
-    }
-    fn as_bytes(&self) -> &[u8] {
-        &self.id
-    }
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        bytes.try_into().ok().map(|id| Self { id })
-    }
-}
-
 #[derive(Debug)]
 struct Dir {
     name: filename3<'static>,
-    parent: fileid3,
+    parent: &FileHandleU64,
     attr: fattr3,
-    content: HashSet<fileid3>,
+    content: HashSet<FileHandleU64>,
 }
 
 impl Dir {
-    fn new(name: filename3<'static>, id: fileid3, parent: fileid3) -> Self {
+    fn new(name: filename3<'static>, id: &FileHandleU64, parent: &FileHandleU64) -> Self {
         let current_time = current_time();
         let attr = fattr3 {
             type_: ftype3::NF3DIR,
@@ -102,7 +85,7 @@ impl Dir {
         Self::new(name, id, 0)
     }
 
-    fn add_entry(&mut self, entry: fileid3) -> bool {
+    fn add_entry(&mut self, entry: &FileHandleU64) -> bool {
         self.content.insert(entry)
     }
 }
@@ -110,13 +93,13 @@ impl Dir {
 #[derive(Debug)]
 struct File {
     name: filename3<'static>,
-    _parent: fileid3,
+    _parent: &FileHandleU64,
     attr: fattr3,
     content: Vec<u8>,
 }
 
 impl File {
-    fn new(name: filename3<'static>, id: fileid3, parent: fileid3, content: Vec<u8>) -> Self {
+    fn new(name: filename3<'static>, id: &FileHandleU64, parent: &FileHandleU64, content: Vec<u8>) -> Self {
         let current_time = current_time();
         let attr = fattr3 {
             type_: ftype3::NF3REG,
@@ -195,11 +178,11 @@ enum Entry {
 }
 
 impl Entry {
-    fn new_file(name: filename3<'static>, id: fileid3, parent: fileid3, content: Vec<u8>) -> Self {
+    fn new_file(name: filename3<'static>, id: &FileHandleU64, parent: &FileHandleU64, content: Vec<u8>) -> Self {
         Self::File(File::new(name, id, parent, content))
     }
 
-    fn new_dir(name: filename3<'static>, id: fileid3, parent: fileid3) -> Self {
+    fn new_dir(name: filename3<'static>, id: &FileHandleU64, parent: &FileHandleU64) -> Self {
         Self::Dir(Dir::new(name, id, parent))
     }
 
@@ -231,7 +214,7 @@ impl Entry {
         }
     }
 
-    const fn fileid(&self) -> fileid3 {
+    const fn fileid(&self) -> FileHandleU64 {
         match self {
             Self::File(file) => file.attr.fileid,
             Self::Dir(dir) => dir.attr.fileid,
@@ -297,8 +280,8 @@ impl Entry {
 
 #[derive(Debug)]
 struct Fs {
-    entries: HashMap<fileid3, Entry>,
-    root: fileid3,
+    entries: HashMap<FileHandleU64, Entry>,
+    root: &FileHandleU64,
 }
 
 impl Fs {
@@ -313,7 +296,7 @@ impl Fs {
         }
     }
 
-    fn push(&mut self, parent: fileid3, entry: Entry) -> Result<(), nfsstat3> {
+    fn push(&mut self, parent: &FileHandleU64, entry: Entry) -> Result<(), nfsstat3> {
         use std::collections::hash_map::Entry as MapEntry;
 
         let id = entry.fileid();
@@ -349,7 +332,7 @@ impl Fs {
         }
     }
 
-    fn remove(&mut self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
+    fn remove(&mut self, dirid: &FileHandleU64, filename: &filename3) -> Result<(), nfsstat3> {
         if filename.as_ref() == b"." || filename.as_ref() == b".." {
             return Err(nfsstat3::NFS3ERR_INVAL);
         }
@@ -384,11 +367,11 @@ impl Fs {
         Ok(())
     }
 
-    fn get(&self, id: fileid3) -> Option<&Entry> {
+    fn get(&self, id: &FileHandleU64) -> Option<&Entry> {
         self.entries.get(&id)
     }
 
-    fn get_mut(&mut self, id: fileid3) -> Option<&mut Entry> {
+    fn get_mut(&mut self, id: &FileHandleU64) -> Option<&mut Entry> {
         self.entries.get_mut(&id)
     }
 }
@@ -399,7 +382,7 @@ impl Fs {
 #[derive(Debug)]
 pub struct MemFs {
     fs: Arc<RwLock<Fs>>,
-    rootdir: fileid3,
+    rootdir: &FileHandleU64,
     nextid: AtomicU64,
 }
 
@@ -428,7 +411,7 @@ impl MemFs {
             if entry.is_dir {
                 fs.add_dir(id, name)?;
             } else {
-                fs.add_file(id, name, sattr3::default(), entry.content)?;
+                fs.add_file(&id, name, sattr3::default(), entry.content)?;
             }
         }
 
@@ -437,14 +420,15 @@ impl MemFs {
 
     fn add_dir(
         &self,
-        dirid: fileid3,
+        dirid: &FileHandleU64,
         dirname: filename3<'static>,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(FileHandleU64, fattr3), nfsstat3> {
         let newid = self
             .nextid
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .into();
 
-        let dir = Entry::new_dir(dirname, newid, dirid);
+        let dir = Entry::new_dir(dirname, &newid, dirid);
         let attr = dir.attr().clone();
 
         self.fs
@@ -457,16 +441,17 @@ impl MemFs {
 
     fn add_file(
         &self,
-        dirid: fileid3,
+        dirid: &FileHandleU64,
         filename: filename3<'static>,
         attr: sattr3,
         content: Vec<u8>,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(FileHandleU64, fattr3), nfsstat3> {
         let newid = self
             .nextid
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .into();
 
-        let mut file = Entry::new_file(filename, newid, dirid, content);
+        let mut file = Entry::new_file(filename, &newid, dirid, content);
         file.set_attr(attr);
         let attr = file.attr().clone();
 
@@ -478,7 +463,7 @@ impl MemFs {
         Ok((newid, attr))
     }
 
-    fn lookup_impl(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
+    fn lookup_impl(&self, dirid: &FileHandleU64, filename: &filename3) -> Result<FileHandleU64, nfsstat3> {
         let fs = self.fs.read().expect("lock is poisoned");
         let entry = fs.get(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
 
@@ -487,14 +472,14 @@ impl MemFs {
         } else if let Entry::Dir(dir) = &entry {
             // if looking for dir/. its the current directory
             if filename.as_ref() == b"." {
-                return Ok(dirid);
+                return Ok(dirid.clone());
             }
             // if looking for dir/.. its the parent directory
             if filename.as_ref() == b".." {
                 return Ok(dir.parent);
             }
             for i in &dir.content {
-                match fs.get(*i) {
+                match fs.get(i) {
                     None => {
                         tracing::error!("invalid entry: {i}");
                         return Err(nfsstat3::NFS3ERR_SERVERFAULT);
@@ -510,22 +495,22 @@ impl MemFs {
         Err(nfsstat3::NFS3ERR_NOENT)
     }
 
-    fn path_to_id_impl(&self, path: &str) -> Result<fileid3, nfsstat3> {
+    fn path_to_id_impl(&self, path: &str) -> Result<FileHandleU64, nfsstat3> {
         let splits = path.split(DELIMITER);
         let mut fid = self.root_dir();
         for component in splits {
             if component.is_empty() {
                 continue;
             }
-            fid = self.lookup_impl(fid, &component.as_bytes().into())?;
+            fid = self.lookup_impl(&fid, &component.as_bytes().into())?;
         }
         Ok(fid)
     }
 
-    fn make_iter(&self, dirid: fileid3, start_after: cookie3) -> Result<MemFsIterator, nfsstat3> {
+    fn make_iter(&self, dirid: &FileHandleU64, start_after: cookie3) -> Result<MemFsIterator, nfsstat3> {
         let fs = self.fs.read().expect("lock is poisoned");
         let entry = fs.get(dirid).ok_or(nfsstat3::NFS3ERR_NOENT)?;
-        let dir = entry.as_dir()?;
+        let dir = entry.as_dir()?;        
 
         let mut iter = dir.content.iter();
         if start_after != 0 {
@@ -541,24 +526,24 @@ impl MemFs {
 }
 
 impl NfsReadFileSystem for MemFs {
-    type Handle = MemFsHandle;
+    type Handle = FileHandleU64;
 
-    fn root_dir(&self) -> fileid3 {
+    fn root_dir(&self) -> FileHandleU64 {
         self.rootdir
     }
 
-    async fn lookup(&self, dirid: fileid3, filename: &filename3<'_>) -> Result<fileid3, nfsstat3> {
+    async fn lookup(&self, dirid: &FileHandleU64, filename: &filename3<'_>) -> Result<FileHandleU64, nfsstat3> {
         self.lookup_impl(dirid, filename)
     }
 
-    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+    async fn getattr(&self, id: &FileHandleU64) -> Result<fattr3, nfsstat3> {
         let fs = self.fs.read().expect("lock is poisoned");
         let entry = fs.get(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         Ok(entry.attr().clone())
     }
     async fn read(
         &self,
-        id: fileid3,
+        id: &FileHandleU64,
         offset: u64,
         count: u32,
     ) -> Result<(Vec<u8>, bool), nfsstat3> {
@@ -570,8 +555,8 @@ impl NfsReadFileSystem for MemFs {
 
     async fn readdir(
         &self,
-        dirid: fileid3,
-        start_after: fileid3,
+        dirid: &FileHandleU64,
+        start_after: &FileHandleU64,
     ) -> Result<impl ReadDirIterator, nfsstat3> {
         let iter = Self::make_iter(self, dirid, start_after)?;
         Ok(iter)
@@ -579,41 +564,41 @@ impl NfsReadFileSystem for MemFs {
 
     async fn readdirplus(
         &self,
-        dirid: fileid3,
-        start_after: fileid3,
+        dirid: &FileHandleU64,
+        start_after: &FileHandleU64,
     ) -> Result<impl ReadDirPlusIterator, nfsstat3> {
         let iter = Self::make_iter(self, dirid, start_after)?;
         Ok(iter)
     }
 
-    /// Converts the fileid to an opaque NFS file handle.
-    fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
-        DEFAULT_FH_CONVERTER.id_to_fh(id)
-    }
-    /// Converts an opaque NFS file handle to a fileid.
-    fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
-        DEFAULT_FH_CONVERTER.fh_to_id(id)
-    }
+    // /// Converts the fileid to an opaque NFS file handle.
+    // fn id_to_fh(&self, id: &FileHandleU64) -> nfs_fh3 {
+    //     DEFAULT_FH_CONVERTER.id_to_fh(id)
+    // }
+    // /// Converts an opaque NFS file handle to a fileid.
+    // fn fh_to_id(&self, id: &nfs_fh3) -> Result<FileHandleU64, nfsstat3> {
+    //     DEFAULT_FH_CONVERTER.fh_to_id(id)
+    // }
 
-    async fn readlink(&self, _id: fileid3) -> Result<nfspath3, nfsstat3> {
+    async fn readlink(&self, _id: &FileHandleU64) -> Result<nfspath3, nfsstat3> {
         tracing::warn!("readlink not implemented");
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
-    async fn lookup_by_path(&self, path: &str) -> Result<fileid3, nfsstat3> {
+    async fn lookup_by_path(&self, path: &str) -> Result<FileHandleU64, nfsstat3> {
         self.path_to_id_impl(path)
     }
 }
 
 impl NfsFileSystem for MemFs {
-    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+    async fn setattr(&self, id: &FileHandleU64, setattr: sattr3) -> Result<fattr3, nfsstat3> {
         let mut fs = self.fs.write().expect("lock is poisoned");
         let entry = fs.get_mut(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         entry.set_attr(setattr);
         Ok(entry.attr().clone())
     }
 
-    async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+    async fn write(&self, id: &FileHandleU64, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
         let mut fs = self.fs.write().expect("lock is poisoned");
 
         let entry = fs.get_mut(id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
@@ -623,31 +608,31 @@ impl NfsFileSystem for MemFs {
 
     async fn create(
         &self,
-        dirid: fileid3,
+        dirid: &FileHandleU64,
         filename: &filename3<'_>,
         attr: sattr3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(FileHandleU64, fattr3), nfsstat3> {
         self.add_file(dirid, filename.clone_to_owned(), attr, Vec::new())
     }
 
     async fn create_exclusive(
         &self,
-        _dirid: fileid3,
+        _dirid: &FileHandleU64,
         _filename: &filename3<'_>,
-    ) -> Result<fileid3, nfsstat3> {
+    ) -> Result<FileHandleU64, nfsstat3> {
         tracing::warn!("create_exclusive not implemented");
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     async fn mkdir(
         &self,
-        dirid: fileid3,
+        dirid: &FileHandleU64,
         dirname: &filename3<'_>,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(FileHandleU64, fattr3), nfsstat3> {
         self.add_dir(dirid, dirname.clone_to_owned())
     }
 
-    async fn remove(&self, dirid: fileid3, filename: &filename3<'_>) -> Result<(), nfsstat3> {
+    async fn remove(&self, dirid: &FileHandleU64, filename: &filename3<'_>) -> Result<(), nfsstat3> {
         self.fs
             .write()
             .expect("lock is poisoned")
@@ -656,9 +641,9 @@ impl NfsFileSystem for MemFs {
 
     async fn rename<'a>(
         &self,
-        _from_dirid: fileid3,
+        _from_dirid: &FileHandleU64,
         _from_filename: &filename3<'a>,
-        _to_dirid: fileid3,
+        _to_dirid: &FileHandleU64,
         _to_filename: &filename3<'a>,
     ) -> Result<(), nfsstat3> {
         tracing::warn!("rename not implemented");
@@ -667,11 +652,11 @@ impl NfsFileSystem for MemFs {
 
     async fn symlink<'a>(
         &self,
-        _dirid: fileid3,
+        _dirid: &FileHandleU64,
         _linkname: &filename3<'a>,
         _symlink: &nfspath3<'a>,
         _attr: &sattr3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(FileHandleU64, fattr3), nfsstat3> {
         tracing::warn!("symlink not implemented");
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
@@ -679,12 +664,12 @@ impl NfsFileSystem for MemFs {
 
 struct MemFsIterator {
     fs: Arc<RwLock<Fs>>,
-    entries: Vec<fileid3>,
+    entries: Vec<FileHandleU64>,
     index: usize,
 }
 
 impl MemFsIterator {
-    const fn new(fs: Arc<RwLock<Fs>>, entries: Vec<fileid3>) -> Self {
+    const fn new(fs: Arc<RwLock<Fs>>, entries: Vec<FileHandleU64>) -> Self {
         Self {
             fs,
             entries,
@@ -710,13 +695,13 @@ impl ReadDirPlusIterator for MemFsIterator {
                 continue;
             };
             let attr = entry.attr().clone();
-            let fh = DEFAULT_FH_CONVERTER.id_to_fh(id);
+            // let fh = DEFAULT_FH_CONVERTER.id_to_fh(id);
             return NextResult::Ok(entryplus3 {
                 fileid: id,
                 name: entry.name().clone_to_owned(),
                 cookie: id,
                 name_attributes: nfs::post_op_attr::Some(attr),
-                name_handle: nfs::post_op_fh3::Some(fh),
+                name_handle: nfs::Nfs3Option::None,
             });
         }
     }

--- a/crates/nfs3_server/src/mount_handlers.rs
+++ b/crates/nfs3_server/src/mount_handlers.rs
@@ -84,8 +84,9 @@ where
 
     match context.vfs.lookup_by_path(path).await {
         Ok(fileid) => {
-            let response = mountres3_ok {
-                fhandle: fhandle3(context.vfs.id_to_fh(&fileid).data),
+            let root = context.file_handle_converter.fh_to_nfs(&fileid);
+            let response = mountres3_ok {                
+                fhandle: fhandle3(root.data),
                 auth_flavors: vec![auth_flavor::AUTH_NULL as u32, auth_flavor::AUTH_UNIX as u32],
             };
             debug!("{xid} --> {response:?}");

--- a/crates/nfs3_server/src/mount_handlers.rs
+++ b/crates/nfs3_server/src/mount_handlers.rs
@@ -82,7 +82,7 @@ where
         return mountres3::Err(mountstat3::MNT3ERR_NOENT);
     };
 
-    match context.vfs.path_to_id(path).await {
+    match context.vfs.lookup_by_path(path).await {
         Ok(fileid) => {
             let response = mountres3_ok {
                 fhandle: fhandle3(context.vfs.id_to_fh(fileid).data),

--- a/crates/nfs3_server/src/mount_handlers.rs
+++ b/crates/nfs3_server/src/mount_handlers.rs
@@ -85,7 +85,7 @@ where
     match context.vfs.lookup_by_path(path).await {
         Ok(fileid) => {
             let root = context.file_handle_converter.fh_to_nfs(&fileid);
-            let response = mountres3_ok {                
+            let response = mountres3_ok {
                 fhandle: fhandle3(root.data),
                 auth_flavors: vec![auth_flavor::AUTH_NULL as u32, auth_flavor::AUTH_UNIX as u32],
             };

--- a/crates/nfs3_server/src/mount_handlers.rs
+++ b/crates/nfs3_server/src/mount_handlers.rs
@@ -85,7 +85,7 @@ where
     match context.vfs.lookup_by_path(path).await {
         Ok(fileid) => {
             let response = mountres3_ok {
-                fhandle: fhandle3(context.vfs.id_to_fh(fileid).data),
+                fhandle: fhandle3(context.vfs.id_to_fh(&fileid).data),
                 auth_flavors: vec![auth_flavor::AUTH_NULL as u32, auth_flavor::AUTH_UNIX as u32],
             };
             debug!("{xid} --> {response:?}");

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -94,7 +94,7 @@ where
     let handle = getattr3args.object;
 
     let id = fh_to_id!(context, &handle);
-    match context.vfs.getattr(id).await {
+    match context.vfs.getattr(&id).await {
         Ok(obj_attributes) => {
             debug!(" {xid} --> {obj_attributes:?}");
             GETATTR3res::Ok(GETATTR3resok { obj_attributes })
@@ -116,13 +116,13 @@ where
 {
     let dirops = lookup3args.what;
     let dirid = fh_to_id!(context, &dirops.dir);
-    let dir_attributes = nfs_option_from_result(context.vfs.getattr(dirid).await);
-    match context.vfs.lookup(dirid, &dirops.name).await {
+    let dir_attributes = nfs_option_from_result(context.vfs.getattr(&dirid).await);
+    match context.vfs.lookup(&dirid, &dirops.name).await {
         Ok(fid) => {
-            let obj_attributes = nfs_option_from_result(context.vfs.getattr(fid).await);
+            let obj_attributes = nfs_option_from_result(context.vfs.getattr(&fid).await);
             debug!("lookup success {} --> {:?}", xid, obj_attributes);
             LOOKUP3res::Ok(LOOKUP3resok {
-                object: context.vfs.id_to_fh(fid),
+                object: context.vfs.id_to_fh(&fid),
                 obj_attributes,
                 dir_attributes,
             })
@@ -144,7 +144,7 @@ where
 {
     let handle = read3args.file;
     let id = fh_to_id!(context, &handle);
-    let file_attributes = nfs_option_from_result(context.vfs.getattr(id).await);
+    let file_attributes = nfs_option_from_result(context.vfs.getattr(&id).await);
     match context
         .vfs
         .read(id, read3args.offset, read3args.count)
@@ -196,7 +196,7 @@ where
     let handle = args.object;
     let mut access = args.access;
     let id = fh_to_id!(context, &handle);
-    let obj_attributes = nfs_option_from_result(context.vfs.getattr(id).await);
+    let obj_attributes = nfs_option_from_result(context.vfs.getattr(&id).await);
 
     // is this a bug?
     if !matches!(context.vfs.capabilities(), VFSCapabilities::ReadWrite) {
@@ -221,7 +221,7 @@ where
     let handle = args.object;
     debug!("nfsproc3_pathconf({xid}, {handle:?})");
     let id = fh_to_id!(context, &handle);
-    let obj_attr = nfs_option_from_result(context.vfs.getattr(id).await);
+    let obj_attr = nfs_option_from_result(context.vfs.getattr(&id).await);
 
     let res = PATHCONF3resok {
         obj_attributes: obj_attr,
@@ -243,7 +243,7 @@ where
 {
     let handle = args.fsroot;
     let id = fh_to_id!(context, &handle);
-    let obj_attr = nfs_option_from_result(context.vfs.getattr(id).await);
+    let obj_attr = nfs_option_from_result(context.vfs.getattr(&id).await);
     let fsstat = FSSTAT3resok {
         obj_attributes: obj_attr,
         tbytes: TEBIBYTE,
@@ -270,7 +270,7 @@ where
     use crate::vfs::ReadDirPlusIterator;
 
     let dirid = fh_to_id!(context, &args.dir);
-    let dir_attr_maybe = context.vfs.getattr(dirid).await;
+    let dir_attr_maybe = context.vfs.getattr(&dirid).await;
 
     let dir_attributes = dir_attr_maybe.map_or(post_op_attr::None, post_op_attr::Some);
 
@@ -349,7 +349,7 @@ where
     }
     let max_bytes_allowed = args.maxcount as usize - 128;
 
-    let iter = context.vfs.readdirplus(dirid, args.cookie).await;
+    let iter = context.vfs.readdirplus(&dirid, args.cookie).await;
 
     if let Err(stat) = iter {
         error!("readdirplus error {xid} --> {stat}");
@@ -392,7 +392,7 @@ where
 
     debug!("  -- readdirplus eof {eof}");
     debug!(
-        "readdirplus {dirid}, has_version {has_version}, start at {}, flushing {} entries, \
+        "readdirplus {dirid:?}, has_version {has_version}, start at {}, flushing {} entries, \
          complete {eof}",
         args.cookie,
         entries.0.len()
@@ -417,7 +417,7 @@ where
     use crate::vfs::ReadDirIterator;
 
     let dirid = fh_to_id!(context, &readdir3args.dir);
-    let dir_attr_maybe = context.vfs.getattr(dirid).await;
+    let dir_attr_maybe = context.vfs.getattr(&dirid).await;
     let dir_attributes = dir_attr_maybe.map_or(post_op_attr::None, post_op_attr::Some);
     let cookieverf = cookieverf3::from_attr(&dir_attributes);
 
@@ -461,7 +461,7 @@ where
     }
     let max_bytes_allowed = readdir3args.count as usize - empty_len;
 
-    let iter = context.vfs.readdir(dirid, readdir3args.cookie).await;
+    let iter = context.vfs.readdir(&dirid, readdir3args.cookie).await;
     if let Err(stat) = iter {
         return READDIR3res::Err((
             stat,
@@ -540,7 +540,7 @@ where
     }
 
     let id = fh_to_id!(context, &write3args.file);
-    let before = get_wcc_attr(context, id)
+    let before = get_wcc_attr(context, &id)
         .await
         .map_or(pre_op_attr::None, pre_op_attr::Some);
 
@@ -592,7 +592,7 @@ where
     debug!("nfsproc3_create({xid}, {dirops:?}, {createhow:?})");
     let dirid = fh_to_id!(context, &dirops.dir);
     // get the object attributes before the write
-    let before = match get_wcc_attr(context, dirid).await {
+    let before = match get_wcc_attr(context, &dirid).await {
         Ok(wccattr) => pre_op_attr::Some(wccattr),
         Err(stat) => {
             warn!("Cannot stat directory {xid} -> {stat}");
@@ -601,8 +601,8 @@ where
     };
 
     if matches!(&createhow, createhow3::GUARDED(_)) {
-        if context.vfs.lookup(dirid, &dirops.name).await.is_ok() {
-            let after = nfs_option_from_result(context.vfs.getattr(dirid).await);
+        if context.vfs.lookup(&dirid, &dirops.name).await.is_ok() {
+            let after = nfs_option_from_result(context.vfs.getattr(&dirid).await);
             return CREATE3res::Err((
                 nfsstat3::NFS3ERR_EXIST,
                 CREATE3resfail {
@@ -614,13 +614,13 @@ where
 
     let (fid, postopattr) = match createhow {
         createhow3::EXCLUSIVE(_) => {
-            let fid = context.vfs.create_exclusive(dirid, &dirops.name).await;
+            let fid = context.vfs.create_exclusive(&dirid, &dirops.name).await;
             (fid, post_op_attr::None)
         }
         createhow3::UNCHECKED(target_attributes) | createhow3::GUARDED(target_attributes) => {
             match context
                 .vfs
-                .create(dirid, &dirops.name, target_attributes)
+                .create(&dirid, &dirops.name, target_attributes)
                 .await
             {
                 Ok((fid, fattr)) => (Ok(fid), post_op_attr::Some(fattr)),
@@ -629,14 +629,14 @@ where
         }
     };
 
-    let after = nfs_option_from_result(context.vfs.getattr(dirid).await);
+    let after = nfs_option_from_result(context.vfs.getattr(&dirid).await);
     let dir_wcc = wcc_data { before, after };
 
     match fid {
         Ok(fid) => {
             debug!("create success {xid} --> {fid:?}, {postopattr:?}");
             CREATE3res::Ok(CREATE3resok {
-                obj: post_op_fh3::Some(context.vfs.id_to_fh(fid)),
+                obj: post_op_fh3::Some(context.vfs.id_to_fh(&fid)),
                 obj_attributes: postopattr,
                 dir_wcc,
             })
@@ -659,7 +659,7 @@ where
 
     let id = fh_to_id!(context, &args.object);
     let ctime;
-    let before = match get_wcc_attr(context, id).await {
+    let before = match get_wcc_attr(context, &id).await {
         Ok(wccattr) => {
             ctime = wccattr.ctime.clone();
             pre_op_attr::Some(wccattr)
@@ -720,7 +720,7 @@ where
     }
 
     let dirid = fh_to_id!(context, &args.object.dir);
-    let before = match get_wcc_attr(context, dirid).await {
+    let before = match get_wcc_attr(context, &dirid).await {
         Ok(v) => pre_op_attr::Some(v),
         Err(stat) => {
             warn!("Cannot stat directory {xid} -> {stat}");
@@ -728,16 +728,16 @@ where
         }
     };
 
-    match context.vfs.remove(dirid, &args.object.name).await {
+    match context.vfs.remove(&dirid, &args.object.name).await {
         Ok(()) => {
-            let after = nfs_option_from_result(context.vfs.getattr(dirid).await);
+            let after = nfs_option_from_result(context.vfs.getattr(&dirid).await);
             debug!("remove success {xid}");
             REMOVE3res::Ok(REMOVE3resok {
                 dir_wcc: wcc_data { before, after },
             })
         }
         Err(stat) => {
-            let after = nfs_option_from_result(context.vfs.getattr(dirid).await);
+            let after = nfs_option_from_result(context.vfs.getattr(&dirid).await);
             error!("remove error {xid} --> {stat}");
             REMOVE3res::Err((
                 stat,
@@ -764,7 +764,7 @@ where
 
     let from_dirid = fh_to_id!(context, &args.from.dir);
     let to_dirid = fh_to_id!(context, &args.to.dir);
-    let pre_from_dir_attr = match get_wcc_attr(context, from_dirid).await {
+    let pre_from_dir_attr = match get_wcc_attr(context, &from_dirid).await {
         Ok(v) => pre_op_attr::Some(v),
         Err(stat) => {
             warn!("Cannot stat source directory {xid} --> {stat}");
@@ -772,7 +772,7 @@ where
         }
     };
 
-    let pre_to_dir_attr = match get_wcc_attr(context, to_dirid).await {
+    let pre_to_dir_attr = match get_wcc_attr(context, &to_dirid).await {
         Ok(v) => pre_op_attr::Some(v),
         Err(stat) => {
             warn!("Cannot stat target directory {xid} --> {stat}");
@@ -782,11 +782,11 @@ where
 
     let result = context
         .vfs
-        .rename(from_dirid, &args.from.name, to_dirid, &args.to.name)
+        .rename(&from_dirid, &args.from.name, &to_dirid, &args.to.name)
         .await;
 
-    let post_from_dir_attr = nfs_option_from_result(context.vfs.getattr(from_dirid).await);
-    let post_to_dir_attr = nfs_option_from_result(context.vfs.getattr(to_dirid).await);
+    let post_from_dir_attr = nfs_option_from_result(context.vfs.getattr(&from_dirid).await);
+    let post_to_dir_attr = nfs_option_from_result(context.vfs.getattr(&to_dirid).await);
 
     let fromdir_wcc = wcc_data {
         before: pre_from_dir_attr,
@@ -827,7 +827,7 @@ where
 
     let dirid = fh_to_id!(context, &args.where_.dir);
 
-    let before = match get_wcc_attr(context, dirid).await {
+    let before = match get_wcc_attr(context, &dirid).await {
         Ok(v) => pre_op_attr::Some(v),
         Err(stat) => {
             warn!("Cannot stat directory {xid} --> {stat}");
@@ -835,8 +835,8 @@ where
         }
     };
 
-    let result = context.vfs.mkdir(dirid, &args.where_.name).await;
-    let after = nfs_option_from_result(context.vfs.getattr(dirid).await);
+    let result = context.vfs.mkdir(&dirid, &args.where_.name).await;
+    let after = nfs_option_from_result(context.vfs.getattr(&dirid).await);
     let dir_wcc = wcc_data { before, after };
 
     match result {
@@ -870,7 +870,7 @@ where
 
     let dirid = fh_to_id!(context, &args.where_.dir);
 
-    let pre_dir_attr = match get_wcc_attr(context, dirid).await {
+    let pre_dir_attr = match get_wcc_attr(context, &dirid).await {
         Ok(v) => pre_op_attr::Some(v),
         Err(stat) => {
             warn!("Cannot stat directory {xid} --> {stat}");
@@ -895,7 +895,7 @@ where
                 obj_attributes: post_op_attr::Some(fattr),
                 dir_wcc: wcc_data {
                     before: pre_dir_attr,
-                    after: nfs_option_from_result(context.vfs.getattr(dirid).await),
+                    after: nfs_option_from_result(context.vfs.getattr(&dirid).await),
                 },
             })
         }
@@ -906,7 +906,7 @@ where
                 SYMLINK3resfail {
                     dir_wcc: wcc_data {
                         before: pre_dir_attr,
-                        after: nfs_option_from_result(context.vfs.getattr(dirid).await),
+                        after: nfs_option_from_result(context.vfs.getattr(&dirid).await),
                     },
                 },
             ))
@@ -944,7 +944,7 @@ fn nfs_option_from_result<T, E>(result: Result<T, E>) -> Nfs3Option<T> {
     result.map_or(Nfs3Option::None, Nfs3Option::Some)
 }
 
-async fn get_wcc_attr<T>(context: &RPCContext<T>, object_id: fileid3) -> Result<wcc_attr, nfsstat3>
+async fn get_wcc_attr<T>(context: &RPCContext<T>, object_id: &T::Handle) -> Result<wcc_attr, nfsstat3>
 where
     T: NfsFileSystem,
 {

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -558,7 +558,7 @@ where
                 },
                 count: write3args.count,
                 committed: stable_how::FILE_SYNC,
-                verf: writeverf3(context.vfs.serverid().0),
+                verf: context.file_handle_converter.verf(),
             })
         }
         Err(stat) => {

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -69,7 +69,7 @@ where
 
 macro_rules! fh_to_id {
     ($context:expr, $fh:expr) => {
-        match $context.vfs.fh_to_id($fh) {
+        match $context.file_handle_converter.fh_from_nfs($fh) {
             Ok(id) => id,
             Err(stat) => {
                 warn!("cannot resolve fh: {stat}");
@@ -122,7 +122,7 @@ where
             let obj_attributes = nfs_option_from_result(context.vfs.getattr(&fid).await);
             debug!("lookup success {} --> {:?}", xid, obj_attributes);
             LOOKUP3res::Ok(LOOKUP3resok {
-                object: context.vfs.id_to_fh(&fid),
+                object: context.file_handle_converter.fh_to_nfs(&fid),
                 obj_attributes,
                 dir_attributes,
             })
@@ -636,7 +636,7 @@ where
         Ok(fid) => {
             debug!("create success {xid} --> {fid:?}, {postopattr:?}");
             CREATE3res::Ok(CREATE3resok {
-                obj: post_op_fh3::Some(context.vfs.id_to_fh(&fid)),
+                obj: post_op_fh3::Some(context.file_handle_converter.fh_to_nfs(&fid)),
                 obj_attributes: postopattr,
                 dir_wcc,
             })
@@ -843,7 +843,7 @@ where
         Ok((fid, fattr)) => {
             debug!("mkdir success {xid} --> {fid:?}, {fattr:?}");
             MKDIR3res::Ok(MKDIR3resok {
-                obj: post_op_fh3::Some(context.vfs.id_to_fh(&fid)),
+                obj: post_op_fh3::Some(context.file_handle_converter.fh_to_nfs(&fid)),
                 obj_attributes: post_op_attr::Some(fattr),
                 dir_wcc,
             })
@@ -891,7 +891,7 @@ where
         Ok((fid, fattr)) => {
             debug!("symlink success {xid} --> {fid:?}, {fattr:?}");
             SYMLINK3res::Ok(SYMLINK3resok {
-                obj: post_op_fh3::Some(context.vfs.id_to_fh(&fid)),
+                obj: post_op_fh3::Some(context.file_handle_converter.fh_to_nfs(&fid)),
                 obj_attributes: post_op_attr::Some(fattr),
                 dir_wcc: wcc_data {
                     before: pre_dir_attr,

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -944,7 +944,10 @@ fn nfs_option_from_result<T, E>(result: Result<T, E>) -> Nfs3Option<T> {
     result.map_or(Nfs3Option::None, Nfs3Option::Some)
 }
 
-async fn get_wcc_attr<T>(context: &RPCContext<T>, object_id: &T::Handle) -> Result<wcc_attr, nfsstat3>
+async fn get_wcc_attr<T>(
+    context: &RPCContext<T>,
+    object_id: &T::Handle,
+) -> Result<wcc_attr, nfsstat3>
 where
     T: NfsFileSystem,
 {

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -147,7 +147,7 @@ where
     let file_attributes = nfs_option_from_result(context.vfs.getattr(&id).await);
     match context
         .vfs
-        .read(id, read3args.offset, read3args.count)
+        .read(&id, read3args.offset, read3args.count)
         .await
     {
         Ok((bytes, eof)) => {
@@ -172,7 +172,7 @@ where
 {
     let handle = args.fsroot;
     let id = fh_to_id!(context, &handle);
-    match context.vfs.fsinfo(id).await {
+    match context.vfs.fsinfo(&id).await {
         Ok(fsinfo) => {
             debug!("fsinfo success {xid} --> {fsinfo:?}");
             FSINFO3res::Ok(fsinfo)
@@ -546,7 +546,7 @@ where
 
     match context
         .vfs
-        .write(id, write3args.offset, &write3args.data)
+        .write(&id, write3args.offset, &write3args.data)
         .await
     {
         Ok(fattr) => {
@@ -685,7 +685,7 @@ where
         }
     }
 
-    match context.vfs.setattr(id, args.new_attributes).await {
+    match context.vfs.setattr(&id, args.new_attributes).await {
         Ok(post_op_attr) => {
             debug!("setattr success {xid} --> {post_op_attr:?}");
             SETATTR3res::Ok(SETATTR3resok {
@@ -843,7 +843,7 @@ where
         Ok((fid, fattr)) => {
             debug!("mkdir success {xid} --> {fid:?}, {fattr:?}");
             MKDIR3res::Ok(MKDIR3resok {
-                obj: post_op_fh3::Some(context.vfs.id_to_fh(fid)),
+                obj: post_op_fh3::Some(context.vfs.id_to_fh(&fid)),
                 obj_attributes: post_op_attr::Some(fattr),
                 dir_wcc,
             })
@@ -881,7 +881,7 @@ where
     match context
         .vfs
         .symlink(
-            dirid,
+            &dirid,
             &args.where_.name,
             &args.symlink.symlink_data,
             &args.symlink.symlink_attributes,
@@ -891,7 +891,7 @@ where
         Ok((fid, fattr)) => {
             debug!("symlink success {xid} --> {fid:?}, {fattr:?}");
             SYMLINK3res::Ok(SYMLINK3resok {
-                obj: post_op_fh3::Some(context.vfs.id_to_fh(fid)),
+                obj: post_op_fh3::Some(context.vfs.id_to_fh(&fid)),
                 obj_attributes: post_op_attr::Some(fattr),
                 dir_wcc: wcc_data {
                     before: pre_dir_attr,
@@ -923,9 +923,9 @@ where
     T: NfsFileSystem,
 {
     let id = fh_to_id!(context, &args.symlink);
-    let symlink_attributes = nfs_option_from_result(context.vfs.getattr(id).await);
+    let symlink_attributes = nfs_option_from_result(context.vfs.getattr(&id).await);
 
-    match context.vfs.readlink(id).await {
+    match context.vfs.readlink(&id).await {
         Ok(data) => {
             debug!("readlink success {xid} --> {data:?}");
             READLINK3res::Ok(READLINK3resok {

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -364,10 +364,7 @@ where
     let mut entries_result = BoundedEntryPlusList::new(args.dircount as usize, max_bytes_allowed);
     loop {
         match iter.next().await {
-            NextResult::Ok(mut entry) => {
-                if entry.name_handle.is_none() {
-                    entry.name_handle = post_op_fh3::Some(context.vfs.id_to_fh(dirid));
-                }
+            NextResult::Ok(entry) => {
                 let result = entries_result.try_push(entry);
                 if result.is_err() {
                     trace!(" -- insufficient space. truncating");

--- a/crates/nfs3_server/src/tcp.rs
+++ b/crates/nfs3_server/src/tcp.rs
@@ -24,6 +24,7 @@ pub struct NFSTcpListener<T: NfsFileSystem + 'static> {
     mount_signal: Option<mpsc::Sender<bool>>,
     export_name: Arc<String>,
     transaction_tracker: Arc<TransactionTracker>,
+    file_handle_converter: crate::vfs::handle::FileHandleConverter,
     stop_notify: Arc<tokio::sync::Notify>,
 }
 
@@ -195,6 +196,7 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
             export_name: Arc::from("/".to_string()),
             transaction_tracker: Self::new_transaction_tracker(),
             stop_notify: Arc::new(tokio::sync::Notify::new()),
+            file_handle_converter: crate::vfs::handle::FileHandleConverter::new(),
         })
     }
 
@@ -274,6 +276,7 @@ impl<T: NfsFileSystem + 'static> NFSTcp for NFSTcpListener<T> {
                 mount_signal: self.mount_signal.clone(),
                 export_name: self.export_name.clone(),
                 transaction_tracker: self.transaction_tracker.clone(),
+                file_handle_converter: self.file_handle_converter.clone(),
             };
             info!("Accepting connection from {}", context.client_addr);
             debug!("Accepting socket {:?} {:?}", socket, context);

--- a/crates/nfs3_server/src/tcp.rs
+++ b/crates/nfs3_server/src/tcp.rs
@@ -276,7 +276,7 @@ impl<T: NfsFileSystem + 'static> NFSTcp for NFSTcpListener<T> {
                 mount_signal: self.mount_signal.clone(),
                 export_name: self.export_name.clone(),
                 transaction_tracker: self.transaction_tracker.clone(),
-                file_handle_converter: self.file_handle_converter.clone(),
+                file_handle_converter: self.file_handle_converter,
             };
             info!("Accepting connection from {}", context.client_addr);
             debug!("Accepting socket {:?} {:?}", socket, context);

--- a/crates/nfs3_server/src/vfs/adapter.rs
+++ b/crates/nfs3_server/src/vfs/adapter.rs
@@ -1,6 +1,6 @@
 //! An adapter for read-only NFS filesystems.
 
-use nfs3_types::nfs3::{cookie3, fattr3, filename3, nfsstat3, sattr3, Nfs3Option};
+use nfs3_types::nfs3::{fattr3, filename3, nfsstat3, sattr3, Nfs3Option};
 
 use super::{
     NextResult, NfsFileSystem, NfsReadFileSystem, ReadDirIterator, ReadDirPlusIterator,

--- a/crates/nfs3_server/src/vfs/adapter.rs
+++ b/crates/nfs3_server/src/vfs/adapter.rs
@@ -28,6 +28,8 @@ impl<T> NfsReadFileSystem for ReadOnlyAdapter<T>
 where
     T: NfsReadFileSystem,
 {
+    type Handle = T::Handle;
+
     fn root_dir(&self) -> fileid3 {
         self.0.root_dir()
     }

--- a/crates/nfs3_server/src/vfs/adapter.rs
+++ b/crates/nfs3_server/src/vfs/adapter.rs
@@ -1,6 +1,6 @@
 //! An adapter for read-only NFS filesystems.
 
-use nfs3_types::nfs3::{fattr3, filename3, nfsstat3, sattr3, Nfs3Option};
+use nfs3_types::nfs3::{Nfs3Option, fattr3, filename3, nfsstat3, sattr3};
 
 use super::{
     NextResult, NfsFileSystem, NfsReadFileSystem, ReadDirIterator, ReadDirPlusIterator,
@@ -34,7 +34,11 @@ where
         self.0.root_dir()
     }
 
-    async fn lookup(&self, dirid: &Self::Handle, filename: &filename3<'_>) -> Result<Self::Handle, nfsstat3> {
+    async fn lookup(
+        &self,
+        dirid: &Self::Handle,
+        filename: &filename3<'_>,
+    ) -> Result<Self::Handle, nfsstat3> {
         self.0.lookup(dirid, filename).await
     }
 
@@ -91,7 +95,12 @@ where
         Err(nfsstat3::NFS3ERR_ROFS)
     }
 
-    async fn write(&self, _id: &Self::Handle, _offset: u64, _data: &[u8]) -> Result<fattr3, nfsstat3> {
+    async fn write(
+        &self,
+        _id: &Self::Handle,
+        _offset: u64,
+        _data: &[u8],
+    ) -> Result<fattr3, nfsstat3> {
         Err(nfsstat3::NFS3ERR_ROFS)
     }
 
@@ -120,7 +129,11 @@ where
         Err(nfsstat3::NFS3ERR_ROFS)
     }
 
-    async fn remove(&self, _dirid: &Self::Handle, _filename: &filename3<'_>) -> Result<(), nfsstat3> {
+    async fn remove(
+        &self,
+        _dirid: &Self::Handle,
+        _filename: &filename3<'_>,
+    ) -> Result<(), nfsstat3> {
         Err(nfsstat3::NFS3ERR_ROFS)
     }
 

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 use nfs3_types::nfs3::{nfs_fh3, nfsstat3};
 use nfs3_types::xdr_codec::Opaque;
 
@@ -86,9 +84,6 @@ impl PartialEq<u64> for FileHandleU64 {
     }
 }
 
-pub(crate) static DEFAULT_FH_CONVERTER: LazyLock<FileHandleConverter> =
-    LazyLock::new(FileHandleConverter::new);
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FileHandleConverter {
     generation_number: u64,
@@ -109,10 +104,6 @@ impl FileHandleConverter {
             generation_number,
             generation_number_le: generation_number.to_le_bytes(),
         }
-    }
-
-    pub(crate) const fn generation_number_le(&self) -> [u8; 8] {
-        self.generation_number_le
     }
 
     pub(crate) fn fh_to_nfs(&self, id: &impl FileHandle) -> nfs_fh3 {

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -2,7 +2,7 @@ use nfs3_types::nfs3::{nfs_fh3, nfsstat3};
 use nfs3_types::xdr_codec::Opaque;
 
 /// Represents a file handle
-/// 
+///
 /// This uniquely identifies a file or folder in the implementation of
 /// [`NfsReadFileSystem`] and [`NfsFileSystem`]. The value is serialized
 /// into a [`nfs_fh3`] handle and sent to the client. The server reserves
@@ -19,9 +19,8 @@ pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
         Self: Sized;
 }
 
-
 /// A file handle that is 8 bytes long
-/// 
+///
 /// If your implementation of [`NfsReadFileSystem`] uses a file handle that is
 /// 8 bytes long, you can use this type.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -32,8 +31,10 @@ pub struct FileHandleU64 {
 impl FileHandleU64 {
     /// Creates a new file handle from a u64
     pub fn new(id: u64) -> Self {
-        Self { id: id.to_ne_bytes() }
-    }    
+        Self {
+            id: id.to_ne_bytes(),
+        }
+    }
 
     pub fn as_u64(&self) -> u64 {
         u64::from_ne_bytes(self.id)
@@ -67,7 +68,7 @@ impl std::fmt::Display for FileHandleU64 {
 }
 
 impl From<u64> for FileHandleU64 {
-    fn from(id: u64) -> Self {        
+    fn from(id: u64) -> Self {
         Self::new(id)
     }
 }

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -1,0 +1,160 @@
+use std::sync::LazyLock;
+
+use nfs3_types::nfs3::{fileid3, nfs_fh3, nfsstat3};
+use nfs3_types::xdr_codec::Opaque;
+
+/// Represents a file handle
+/// 
+/// This uniquely identifies a file or folder in the implementation of
+/// [`NfsReadFileSystem`] and [`NfsFileSystem`]. The value is serialized
+/// into a [`nfs_fh3`] handle and sent to the client. The server reserves
+/// the first 8 bytes of the handle for its own use, while the remaining
+/// 56 bytes can be freely used by the implementation.
+pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
+    /// The length of the handle in bytes
+    fn len(&self) -> usize;
+    /// Returns the handle as a byte slice
+    fn as_bytes(&self) -> &[u8];
+    /// Creates a handle from a byte slice
+    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+
+/// A file handle that is 8 bytes long
+/// 
+/// If your implementation of [`NfsReadFileSystem`] uses a file handle that is
+/// 8 bytes long, you can use this type.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct FileHandleU64 {
+    id: [u8; 8],
+}
+
+impl FileHandle for FileHandleU64 {
+    fn len(&self) -> usize {
+        self.id.len()
+    }
+    fn as_bytes(&self) -> &[u8] {
+        &self.id
+    }
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytes.try_into().ok().map(|id| Self { id })
+    }
+}
+
+impl std::fmt::Debug for FileHandleU64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FileHandleU64")
+            .field(&u64::from_ne_bytes(self.id))
+            .finish()
+    }
+}
+
+impl std::fmt::Display for FileHandleU64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", u64::from_ne_bytes(self.id))
+    }
+}
+
+impl From<u64> for FileHandleU64 {
+    fn from(id: u64) -> Self {        
+        Self { id: id.to_ne_bytes() }
+    }
+}
+
+impl Into<u64> for FileHandleU64 {
+    fn into(self) -> u64 {
+        u64::from_ne_bytes(self.id)
+    }
+}
+
+impl PartialEq<u64> for FileHandleU64 {
+    fn eq(&self, other: &u64) -> bool {
+        self.id == other.to_ne_bytes()
+    }
+}
+
+pub(crate) static DEFAULT_FH_CONVERTER: LazyLock<DefaultNfsFhConverter> =
+    LazyLock::new(DefaultNfsFhConverter::new);
+
+pub(crate) struct DefaultNfsFhConverter {
+    generation_number: u64,
+    generation_number_le: [u8; 8],
+}
+
+impl DefaultNfsFhConverter {
+    const HANDLE_LENGTH: usize = 16;
+
+    #[allow(clippy::cast_possible_truncation)] // it's ok to truncate the generation number
+    pub(crate) fn new() -> Self {
+        let generation_number = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("failed to get system time")
+            .as_millis() as u64;
+
+        Self {
+            generation_number,
+            generation_number_le: generation_number.to_le_bytes(),
+        }
+    }
+
+    pub(crate) fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
+        let mut ret: Vec<u8> = Vec::with_capacity(Self::HANDLE_LENGTH);
+        ret.extend_from_slice(&self.generation_number_le);
+        ret.extend_from_slice(&id.to_le_bytes());
+        nfs_fh3 {
+            data: Opaque::owned(ret),
+        }
+    }
+    pub(crate) fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
+        self.check_handle(id)?;
+
+        Ok(u64::from_le_bytes(
+            id.data[8..16]
+                .try_into()
+                .map_err(|_| nfsstat3::NFS3ERR_BADHANDLE)?,
+        ))
+    }
+    pub(crate) const fn generation_number_le(&self) -> [u8; 8] {
+        self.generation_number_le
+    }
+
+    pub(crate) fn fh_to_nfs(&self, id: &impl FileHandle) -> nfs_fh3 {
+        let mut ret: Vec<u8> = Vec::with_capacity(8 + id.len());
+        ret.extend_from_slice(&self.generation_number_le);
+        ret.extend_from_slice(id.as_bytes());
+        nfs_fh3 {
+            data: Opaque::owned(ret),
+        }
+    }
+
+    pub(crate) fn fh_from_nfs<FH>(&self, id: &nfs_fh3) -> Result<FH, nfsstat3>
+    where
+        FH: FileHandle,
+    {
+        self.check_handle(id)?;
+
+        FH::from_bytes(&id.data[8..]).ok_or(nfsstat3::NFS3ERR_BADHANDLE)
+    }
+
+    fn check_handle(&self, id: &nfs_fh3) -> Result<(), nfsstat3> {
+        if id.data.len() != Self::HANDLE_LENGTH {
+            return Err(nfsstat3::NFS3ERR_BADHANDLE);
+        }
+        if id.data[0..8] == self.generation_number_le {
+            Ok(())
+        } else {
+            let id_gen = u64::from_le_bytes(
+                id.data[0..8]
+                    .try_into()
+                    .map_err(|_| nfsstat3::NFS3ERR_BADHANDLE)?,
+            );
+            if id_gen < self.generation_number {
+                Err(nfsstat3::NFS3ERR_STALE)
+            } else {
+                Err(nfsstat3::NFS3ERR_BADHANDLE)
+            }
+        }
+    }
+}

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -1,4 +1,4 @@
-use nfs3_types::nfs3::{nfs_fh3, nfsstat3};
+use nfs3_types::nfs3::{nfs_fh3, nfsstat3, writeverf3};
 use nfs3_types::xdr_codec::Opaque;
 
 /// Represents a file handle
@@ -150,6 +150,16 @@ impl FileHandleConverter {
                 Err(nfsstat3::NFS3ERR_BADHANDLE)
             }
         }
+    }
+
+    /// This is a cookie that the client can use to determine
+    /// whether the server has rebooted between a call to WRITE
+    /// and a subsequent call to COMMIT. This cookie must be
+    /// consistent during a single boot session and must be
+    /// unique between instances of the NFS version 3 protocol
+    /// server where uncommitted data may be lost.
+    pub fn verf(&self) -> writeverf3 {
+        writeverf3(self.generation_number_le)        
     }
 }
 

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -8,7 +8,7 @@ use nfs3_types::xdr_codec::Opaque;
 /// into a [`nfs_fh3`] handle and sent to the client. The server reserves
 /// the first 8 bytes of the handle for its own use, while the remaining
 /// 56 bytes can be freely used by the implementation.
-/// 
+///
 /// [1]: crate::vfs::NfsReadFileSystem
 /// [2]: crate::vfs::NfsFileSystem
 #[expect(clippy::len_without_is_empty)]
@@ -27,7 +27,7 @@ pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
 ///
 /// If your implementation of [`NfsReadFileSystem`][1] uses a file handle that is
 /// 8 bytes long, you can use this type instead of creating you own.
-/// 
+///
 /// [1]: crate::vfs::NfsReadFileSystem
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FileHandleU64 {
@@ -165,7 +165,10 @@ mod tests {
         assert_eq!(handle.as_u64(), 42);
         assert_eq!(handle.len(), 8);
         assert_eq!(handle.as_bytes(), &[42, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(FileHandleU64::from_bytes(&[42, 0, 0, 0, 0, 0, 0, 0]), Some(handle));
+        assert_eq!(
+            FileHandleU64::from_bytes(&[42, 0, 0, 0, 0, 0, 0, 0]),
+            Some(handle)
+        );
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,14 +204,18 @@ mod tests {
     fn test_file_handle_converter_19bytes() {
         let converter = FileHandleConverter::new();
         let handle = TestHandle {
-            id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+            id: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+            ],
         };
         let nfs_handle = converter.fh_to_nfs(&handle);
         assert_eq!(nfs_handle.data.len(), 27);
         assert_eq!(nfs_handle.data[0..8], converter.generation_number_le);
         assert_eq!(&nfs_handle.data[8..], handle.as_bytes());
 
-        let converted_handle = converter.fh_from_nfs::<TestHandle<19>>(&nfs_handle).unwrap();
+        let converted_handle = converter
+            .fh_from_nfs::<TestHandle<19>>(&nfs_handle)
+            .unwrap();
         assert_eq!(converted_handle, handle);
     }
 }

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -4,10 +4,13 @@ use nfs3_types::xdr_codec::Opaque;
 /// Represents a file handle
 ///
 /// This uniquely identifies a file or folder in the implementation of
-/// [`NfsReadFileSystem`] and [`NfsFileSystem`]. The value is serialized
+/// [`NfsReadFileSystem`][1] and [`NfsFileSystem`][2]. The value is serialized
 /// into a [`nfs_fh3`] handle and sent to the client. The server reserves
 /// the first 8 bytes of the handle for its own use, while the remaining
 /// 56 bytes can be freely used by the implementation.
+/// 
+/// [1]: crate::vfs::NfsReadFileSystem
+/// [2]: crate::vfs::NfsFileSystem
 #[expect(clippy::len_without_is_empty)]
 pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
     /// The length of the handle in bytes
@@ -20,10 +23,12 @@ pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
         Self: Sized;
 }
 
-/// A file handle that is 8 bytes long
+/// A basic 8-bytes long file handle
 ///
-/// If your implementation of [`NfsReadFileSystem`] uses a file handle that is
-/// 8 bytes long, you can use this type.
+/// If your implementation of [`NfsReadFileSystem`][1] uses a file handle that is
+/// 8 bytes long, you can use this type instead of creating you own.
+/// 
+/// [1]: crate::vfs::NfsReadFileSystem
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FileHandleU64 {
     id: [u8; 8],
@@ -38,6 +43,7 @@ impl FileHandleU64 {
         }
     }
 
+    /// Converts the file handle to a u64
     #[must_use]
     pub const fn as_u64(&self) -> u64 {
         u64::from_ne_bytes(self.id)

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -158,8 +158,8 @@ impl FileHandleConverter {
     /// consistent during a single boot session and must be
     /// unique between instances of the NFS version 3 protocol
     /// server where uncommitted data may be lost.
-    pub fn verf(&self) -> writeverf3 {
-        writeverf3(self.generation_number_le)        
+    pub const fn verf(&self) -> writeverf3 {
+        writeverf3(self.generation_number_le)
     }
 }
 

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -26,7 +26,7 @@ pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
 /// 
 /// If your implementation of [`NfsReadFileSystem`] uses a file handle that is
 /// 8 bytes long, you can use this type.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FileHandleU64 {
     id: [u8; 8],
 }

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -155,7 +155,7 @@ impl FileHandleConverter {
 
 #[cfg(test)]
 mod tests {
-    use std::usize;
+    #![expect(clippy::unwrap_used)]
 
     use super::*;
 

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -8,6 +8,7 @@ use nfs3_types::xdr_codec::Opaque;
 /// into a [`nfs_fh3`] handle and sent to the client. The server reserves
 /// the first 8 bytes of the handle for its own use, while the remaining
 /// 56 bytes can be freely used by the implementation.
+#[expect(clippy::len_without_is_empty)]
 pub trait FileHandle: std::fmt::Debug + Clone + Send + Sync {
     /// The length of the handle in bytes
     fn len(&self) -> usize;
@@ -30,13 +31,15 @@ pub struct FileHandleU64 {
 
 impl FileHandleU64 {
     /// Creates a new file handle from a u64
-    pub fn new(id: u64) -> Self {
+    #[must_use]
+    pub const fn new(id: u64) -> Self {
         Self {
             id: id.to_ne_bytes(),
         }
     }
 
-    pub fn as_u64(&self) -> u64 {
+    #[must_use]
+    pub const fn as_u64(&self) -> u64 {
         u64::from_ne_bytes(self.id)
     }
 }
@@ -73,9 +76,9 @@ impl From<u64> for FileHandleU64 {
     }
 }
 
-impl Into<u64> for FileHandleU64 {
-    fn into(self) -> u64 {
-        self.as_u64()
+impl From<FileHandleU64> for u64 {
+    fn from(val: FileHandleU64) -> Self {
+        val.as_u64()
     }
 }
 
@@ -86,7 +89,7 @@ impl PartialEq<u64> for FileHandleU64 {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct FileHandleConverter {
+pub struct FileHandleConverter {
     generation_number: u64,
     generation_number_le: [u8; 8],
 }

--- a/crates/nfs3_server/src/vfs/iterator.rs
+++ b/crates/nfs3_server/src/vfs/iterator.rs
@@ -22,9 +22,6 @@ pub trait ReadDirIterator: Send + Sync {
 /// Iterator for [`NfsReadFileSystem::readdirplus`](super::NfsReadFileSystem::readdirplus)
 pub trait ReadDirPlusIterator: Send + Sync {
     /// Returns the next entry in the directory.
-    ///
-    /// If `entryplus3::name_handle` field is `None`, it will be filled automatically using
-    /// [`NfsReadFileSystem::id_to_fh`](super::NfsReadFileSystem::id_to_fh).
     fn next(&mut self) -> impl Future<Output = NextResult<entryplus3<'static>>> + Send;
 }
 

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -80,7 +80,7 @@ pub trait NfsReadFileSystem: Send + Sync {
                 if component.is_empty() {
                     continue;
                 }
-                fid = self.lookup(fid, &component.as_bytes().into()).await?;
+                fid = self.lookup(&fid, &component.as_bytes().into()).await?;
             }
             Ok(fid)
         }

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -50,7 +50,7 @@ pub trait NfsReadFileSystem: Send + Sync {
     /// Type that can be used to indentify a file or folder in the file system.
     ///
     /// This will be used to form [`nfs_fh3`] handles.
-    /// NOTE: Maximum size of nfs_fh3 is 60 bytes.
+    /// NOTE: Maximum size of `nfs_fh3` is 60 bytes.
     ///       4 bytes are reserved for server unique id.
     type Handle: FileHandle;
 
@@ -137,7 +137,7 @@ pub trait NfsReadFileSystem: Send + Sync {
     ) -> impl Future<Output = Result<fsinfo3, nfsstat3>> + Send {
         async move {
             let dir_attr = self
-                .getattr(&root_fileid)
+                .getattr(root_fileid)
                 .await
                 .map_or(post_op_attr::None, post_op_attr::Some);
 

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -106,12 +106,27 @@ pub enum VFSCapabilities {
     ReadWrite,
 }
 
+pub trait FileHandle {
+    fn len(&self) -> usize;
+    fn as_bytes(&self) -> &[u8];
+    fn from_bytes(bytes: &[u8]) -> Option<Self>
+    where
+        Self: Sized;
+}
+
 /// Read-only file system interface
 ///
 /// This should be enough to implement a read-only NFS server.
 /// If you want to implement a read-write server, you should implement
 /// the [`NfsFileSystem`] trait too.
 pub trait NfsReadFileSystem: Send + Sync {
+    /// Type that can be used to indentify a file or folder in the file system.
+    ///
+    /// This will be used to form [`nfs_fh3`] handles.
+    /// NOTE: Maximum size of nfs_fh3 is 60 bytes.
+    ///       4 bytes are reserved for server unique id.
+    type Handle: FileHandle;
+
     /// Returns the ID the of the root directory "/"
     fn root_dir(&self) -> fileid3;
     /// Look up the id of a path in a directory

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -22,7 +22,7 @@
 //!  The 0 fileid is reserved and should not be used
 
 pub mod adapter;
-mod handle;
+pub(crate) mod handle;
 mod iterator;
 
 use handle::DEFAULT_FH_CONVERTER;

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -49,15 +49,12 @@ pub enum VFSCapabilities {
 pub trait NfsReadFileSystem: Send + Sync {
     /// Type that can be used to indentify a file or folder in the file system.
     ///
-    /// This will be used to form [`nfs_fh3`][1] handles.
-    /// NOTE: Maximum size of `nfs_fh3` is 60 bytes.
-    ///       4 bytes are reserved for server unique id.
-    ///
-    /// [1]: nfs3_types::nfs3::nfs_fh3
+    /// For more information, see [`FileHandle`].
     type Handle: FileHandle;
 
     /// Returns the ID the of the root directory "/"
     fn root_dir(&self) -> Self::Handle;
+
     /// Look up the id of a path in a directory
     ///
     /// i.e. given a directory dir/ containing a file `a.txt`

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -28,7 +28,7 @@ mod iterator;
 pub use handle::{FileHandle, FileHandleU64};
 pub use iterator::*;
 use nfs3_types::nfs3::{
-    FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, cookieverf3, fattr3,
+    FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, fattr3,
     filename3, nfspath3, nfstime3, post_op_attr, sattr3,
 };
 
@@ -48,7 +48,7 @@ pub enum VFSCapabilities {
 /// the [`NfsFileSystem`] trait too.
 pub trait NfsReadFileSystem: Send + Sync {
     /// Type that can be used to indentify a file or folder in the file system.
-    ///
+    /// 
     /// For more information, see [`FileHandle`].
     type Handle: FileHandle;
 
@@ -158,10 +158,6 @@ pub trait NfsReadFileSystem: Send + Sync {
             };
             Ok(res)
         }
-    }
-
-    fn serverid(&self) -> cookieverf3 {
-        cookieverf3(0u64.to_be_bytes())
     }
 }
 

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -25,12 +25,11 @@ pub mod adapter;
 pub(crate) mod handle;
 mod iterator;
 
-use handle::DEFAULT_FH_CONVERTER;
 pub use handle::{FileHandle, FileHandleU64};
 pub use iterator::*;
 use nfs3_types::nfs3::{
     FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, cookieverf3, fattr3,
-    filename3, nfs_fh3, nfspath3, nfstime3, post_op_attr, sattr3,
+    filename3, nfspath3, nfstime3, post_op_attr, sattr3,
 };
 
 use crate::units::{GIBIBYTE, MEBIBYTE};
@@ -156,17 +155,8 @@ pub trait NfsReadFileSystem: Send + Sync {
         }
     }
 
-    /// Converts the fileid to an opaque NFS file handle. Optional.
-    fn id_to_fh(&self, id: &Self::Handle) -> nfs_fh3 {
-        DEFAULT_FH_CONVERTER.fh_to_nfs(id)
-    }
-    /// Converts an opaque NFS file handle to a fileid.  Optional.
-    fn fh_to_id(&self, id: &nfs_fh3) -> Result<Self::Handle, nfsstat3> {
-        DEFAULT_FH_CONVERTER.fh_from_nfs(id)
-    }
-
     fn serverid(&self) -> cookieverf3 {
-        cookieverf3(DEFAULT_FH_CONVERTER.generation_number_le())
+        cookieverf3(0u64.to_be_bytes())
     }
 }
 

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -28,8 +28,8 @@ mod iterator;
 pub use handle::{FileHandle, FileHandleU64};
 pub use iterator::*;
 use nfs3_types::nfs3::{
-    FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, fattr3,
-    filename3, nfspath3, nfstime3, post_op_attr, sattr3,
+    FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, fattr3, filename3,
+    nfspath3, nfstime3, post_op_attr, sattr3,
 };
 
 use crate::units::{GIBIBYTE, MEBIBYTE};
@@ -48,7 +48,7 @@ pub enum VFSCapabilities {
 /// the [`NfsFileSystem`] trait too.
 pub trait NfsReadFileSystem: Send + Sync {
     /// Type that can be used to indentify a file or folder in the file system.
-    /// 
+    ///
     /// For more information, see [`FileHandle`].
     type Handle: FileHandle;
 

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -52,7 +52,7 @@ pub trait NfsReadFileSystem: Send + Sync {
     /// This will be used to form [`nfs_fh3`][1] handles.
     /// NOTE: Maximum size of `nfs_fh3` is 60 bytes.
     ///       4 bytes are reserved for server unique id.
-    /// 
+    ///
     /// [1]: nfs3_types::nfs3::nfs_fh3
     type Handle: FileHandle;
 

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -49,9 +49,11 @@ pub enum VFSCapabilities {
 pub trait NfsReadFileSystem: Send + Sync {
     /// Type that can be used to indentify a file or folder in the file system.
     ///
-    /// This will be used to form [`nfs_fh3`] handles.
+    /// This will be used to form [`nfs_fh3`][1] handles.
     /// NOTE: Maximum size of `nfs_fh3` is 60 bytes.
     ///       4 bytes are reserved for server unique id.
+    /// 
+    /// [1]: nfs3_types::nfs3::nfs_fh3
     type Handle: FileHandle;
 
     /// Returns the ID the of the root directory "/"
@@ -70,7 +72,7 @@ pub trait NfsReadFileSystem: Send + Sync {
     ) -> impl Future<Output = Result<Self::Handle, nfsstat3>> + Send;
 
     /// This method is used when the client tries to mount a subdirectory.
-    /// The default implementation walks the directory structure with [`lookup`]
+    /// The default implementation walks the directory structure with [`lookup`](Self::lookup).
     fn lookup_by_path(
         &self,
         path: &str,

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -71,7 +71,10 @@ pub trait NfsReadFileSystem: Send + Sync {
 
     /// This method is used when the client tries to mount a subdirectory.
     /// The default implementation walks the directory structure with [`lookup`]
-    fn lookup_by_path(&self, path: &str) -> impl Future<Output = Result<Self::Handle, nfsstat3>> + Send {
+    fn lookup_by_path(
+        &self,
+        path: &str,
+    ) -> impl Future<Output = Result<Self::Handle, nfsstat3>> + Send {
         async move {
             let splits = path.split('/');
             let mut fid = self.root_dir();
@@ -122,7 +125,10 @@ pub trait NfsReadFileSystem: Send + Sync {
     ) -> impl Future<Output = Result<impl ReadDirPlusIterator, nfsstat3>> + Send;
 
     /// Reads a symlink
-    fn readlink(&self, id: &Self::Handle) -> impl Future<Output = Result<nfspath3, nfsstat3>> + Send;
+    fn readlink(
+        &self,
+        id: &Self::Handle,
+    ) -> impl Future<Output = Result<nfspath3, nfsstat3>> + Send;
 
     /// Get static file system Information
     fn fsinfo(

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -22,96 +22,24 @@
 //!  The 0 fileid is reserved and should not be used
 
 pub mod adapter;
+mod handle;
 mod iterator;
 
-use std::sync::LazyLock;
-use std::time::SystemTime;
-
+use handle::DEFAULT_FH_CONVERTER;
+pub use handle::{FileHandle, FileHandleU64};
 pub use iterator::*;
 use nfs3_types::nfs3::{
     FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, cookieverf3, fattr3,
-    fileid3, filename3, nfs_fh3, nfspath3, nfstime3, post_op_attr, sattr3,
+    filename3, nfs_fh3, nfspath3, nfstime3, post_op_attr, sattr3,
 };
-use nfs3_types::xdr_codec::Opaque;
 
 use crate::units::{GIBIBYTE, MEBIBYTE};
-
-pub(crate) static DEFAULT_FH_CONVERTER: LazyLock<DefaultNfsFhConverter> =
-    LazyLock::new(DefaultNfsFhConverter::new);
-
-pub(crate) struct DefaultNfsFhConverter {
-    generation_number: u64,
-    generation_number_le: [u8; 8],
-}
-
-impl DefaultNfsFhConverter {
-    const HANDLE_LENGTH: usize = 16;
-
-    #[allow(clippy::cast_possible_truncation)] // it's ok to truncate the generation number
-    pub(crate) fn new() -> Self {
-        let generation_number = SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("failed to get system time")
-            .as_millis() as u64;
-
-        Self {
-            generation_number,
-            generation_number_le: generation_number.to_le_bytes(),
-        }
-    }
-
-    /// Converts the fileid to an opaque NFS file handle. Optional.
-    pub(crate) fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
-        let mut ret: Vec<u8> = Vec::with_capacity(Self::HANDLE_LENGTH);
-        ret.extend_from_slice(&self.generation_number_le);
-        ret.extend_from_slice(&id.to_le_bytes());
-        nfs_fh3 {
-            data: Opaque::owned(ret),
-        }
-    }
-    /// Converts an opaque NFS file handle to a fileid.  Optional.
-    pub(crate) fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
-        if id.data.len() != Self::HANDLE_LENGTH {
-            return Err(nfsstat3::NFS3ERR_BADHANDLE);
-        }
-
-        if id.data[0..8] == self.generation_number_le {
-            Ok(u64::from_le_bytes(
-                id.data[8..16]
-                    .try_into()
-                    .map_err(|_| nfsstat3::NFS3ERR_BADHANDLE)?,
-            ))
-        } else {
-            let id_gen = u64::from_le_bytes(
-                id.data[0..8]
-                    .try_into()
-                    .map_err(|_| nfsstat3::NFS3ERR_BADHANDLE)?,
-            );
-            if id_gen < self.generation_number {
-                Err(nfsstat3::NFS3ERR_STALE)
-            } else {
-                Err(nfsstat3::NFS3ERR_BADHANDLE)
-            }
-        }
-    }
-    pub(crate) const fn generation_number_le(&self) -> [u8; 8] {
-        self.generation_number_le
-    }
-}
 
 /// What capabilities are supported
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VFSCapabilities {
     ReadOnly,
     ReadWrite,
-}
-
-pub trait FileHandle {
-    fn len(&self) -> usize;
-    fn as_bytes(&self) -> &[u8];
-    fn from_bytes(bytes: &[u8]) -> Option<Self>
-    where
-        Self: Sized;
 }
 
 /// Read-only file system interface
@@ -128,7 +56,7 @@ pub trait NfsReadFileSystem: Send + Sync {
     type Handle: FileHandle;
 
     /// Returns the ID the of the root directory "/"
-    fn root_dir(&self) -> fileid3;
+    fn root_dir(&self) -> Self::Handle;
     /// Look up the id of a path in a directory
     ///
     /// i.e. given a directory dir/ containing a file `a.txt`
@@ -138,13 +66,13 @@ pub trait NfsReadFileSystem: Send + Sync {
     /// This method should be fast as it is used very frequently.
     fn lookup(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         filename: &filename3<'_>,
-    ) -> impl Future<Output = Result<fileid3, nfsstat3>> + Send;
+    ) -> impl Future<Output = Result<Self::Handle, nfsstat3>> + Send;
 
     /// This method is used when the client tries to mount a subdirectory.
     /// The default implementation walks the directory structure with [`lookup`]
-    fn lookup_by_path(&self, path: &str) -> impl Future<Output = Result<fileid3, nfsstat3>> + Send {
+    fn lookup_by_path(&self, path: &str) -> impl Future<Output = Result<Self::Handle, nfsstat3>> + Send {
         async move {
             let splits = path.split('/');
             let mut fid = self.root_dir();
@@ -160,7 +88,7 @@ pub trait NfsReadFileSystem: Send + Sync {
 
     /// Returns the attributes of an id.
     /// This method should be fast as it is used very frequently.
-    fn getattr(&self, id: fileid3) -> impl Future<Output = Result<fattr3, nfsstat3>> + Send;
+    fn getattr(&self, id: &Self::Handle) -> impl Future<Output = Result<fattr3, nfsstat3>> + Send;
 
     /// Reads the contents of a file returning (bytes, EOF)
     /// Note that offset/count may go past the end of the file and that
@@ -168,7 +96,7 @@ pub trait NfsReadFileSystem: Send + Sync {
     /// EOF must be flagged if the end of the file is reached by the read.
     fn read(
         &self,
-        id: fileid3,
+        id: &Self::Handle,
         offset: u64,
         count: u32,
     ) -> impl Future<Output = Result<(Vec<u8>, bool), nfsstat3>> + Send;
@@ -177,8 +105,8 @@ pub trait NfsReadFileSystem: Send + Sync {
     /// Only need to return filename and id
     fn readdir(
         &self,
-        dirid: fileid3,
-        start_after: fileid3,
+        dirid: &Self::Handle,
+        cookie: u64,
     ) -> impl Future<Output = Result<impl ReadDirIterator, nfsstat3>> + Send;
 
     /// Returns the contents of a directory with pagination.
@@ -190,21 +118,21 @@ pub trait NfsReadFileSystem: Send + Sync {
     /// and `start_after=6`, readdir should returning 2,11,8,...
     fn readdirplus(
         &self,
-        dirid: fileid3,
-        start_after: fileid3,
+        dirid: &Self::Handle,
+        cookie: u64,
     ) -> impl Future<Output = Result<impl ReadDirPlusIterator, nfsstat3>> + Send;
 
     /// Reads a symlink
-    fn readlink(&self, id: fileid3) -> impl Future<Output = Result<nfspath3, nfsstat3>> + Send;
+    fn readlink(&self, id: &Self::Handle) -> impl Future<Output = Result<nfspath3, nfsstat3>> + Send;
 
     /// Get static file system Information
     fn fsinfo(
         &self,
-        root_fileid: fileid3,
+        root_fileid: &Self::Handle,
     ) -> impl Future<Output = Result<fsinfo3, nfsstat3>> + Send {
         async move {
             let dir_attr = self
-                .getattr(root_fileid)
+                .getattr(&root_fileid)
                 .await
                 .map_or(post_op_attr::None, post_op_attr::Some);
 
@@ -229,12 +157,12 @@ pub trait NfsReadFileSystem: Send + Sync {
     }
 
     /// Converts the fileid to an opaque NFS file handle. Optional.
-    fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
-        DEFAULT_FH_CONVERTER.id_to_fh(id)
+    fn id_to_fh(&self, id: &Self::Handle) -> nfs_fh3 {
+        DEFAULT_FH_CONVERTER.fh_to_nfs(id)
     }
     /// Converts an opaque NFS file handle to a fileid.  Optional.
-    fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
-        DEFAULT_FH_CONVERTER.fh_to_id(id)
+    fn fh_to_id(&self, id: &nfs_fh3) -> Result<Self::Handle, nfsstat3> {
+        DEFAULT_FH_CONVERTER.fh_from_nfs(id)
     }
 
     fn serverid(&self) -> cookieverf3 {
@@ -255,7 +183,7 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)` if readonly
     fn setattr(
         &self,
-        id: fileid3,
+        id: &Self::Handle,
         setattr: sattr3,
     ) -> impl Future<Output = Result<fattr3, nfsstat3>> + Send;
 
@@ -273,7 +201,7 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// value for the NFS version 3 protocol is `NFS3ERR_INVAL`.
     fn write(
         &self,
-        id: fileid3,
+        id: &Self::Handle,
         offset: u64,
         data: &[u8],
     ) -> impl Future<Output = Result<fattr3, nfsstat3>> + Send;
@@ -283,34 +211,34 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
     fn create(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         filename: &filename3<'_>,
         attr: sattr3,
-    ) -> impl Future<Output = Result<(fileid3, fattr3), nfsstat3>> + Send;
+    ) -> impl Future<Output = Result<(Self::Handle, fattr3), nfsstat3>> + Send;
 
     /// Creates a file if it does not already exist
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
     fn create_exclusive(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         filename: &filename3<'_>,
-    ) -> impl Future<Output = Result<fileid3, nfsstat3>> + Send;
+    ) -> impl Future<Output = Result<Self::Handle, nfsstat3>> + Send;
 
     /// Makes a directory with the following attributes.
     /// If not supported dur to readonly file system
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
     fn mkdir(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         dirname: &filename3<'_>,
-    ) -> impl Future<Output = Result<(fileid3, fattr3), nfsstat3>> + Send;
+    ) -> impl Future<Output = Result<(Self::Handle, fattr3), nfsstat3>> + Send;
 
     /// Removes a file.
     /// If not supported due to readonly file system
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
     fn remove(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         filename: &filename3<'_>,
     ) -> impl Future<Output = Result<(), nfsstat3>> + Send;
 
@@ -319,9 +247,9 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
     fn rename<'a>(
         &self,
-        from_dirid: fileid3,
+        from_dirid: &Self::Handle,
         from_filename: &filename3<'a>,
-        to_dirid: fileid3,
+        to_dirid: &Self::Handle,
         to_filename: &filename3<'a>,
     ) -> impl Future<Output = Result<(), nfsstat3>> + Send;
 
@@ -330,9 +258,9 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
     fn symlink<'a>(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         linkname: &filename3<'a>,
         symlink: &nfspath3<'a>,
         attr: &sattr3,
-    ) -> impl Future<Output = Result<(fileid3, fattr3), nfsstat3>> + Send;
+    ) -> impl Future<Output = Result<(Self::Handle, fattr3), nfsstat3>> + Send;
 }

--- a/crates/nfs3_tests/src/server.rs
+++ b/crates/nfs3_tests/src/server.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
-use std::time::Duration;
 
-use nfs3_server::test_reexports::{RPCContext, TransactionTracker};
+use nfs3_server::test_reexports::RPCContext;
 use nfs3_server::vfs::NfsFileSystem;
 use nfs3_types::nfs3::nfs_fh3;
 
@@ -16,26 +15,13 @@ where
     FS: NfsFileSystem + 'static,
 {
     pub fn new(io: IO, memfs: FS) -> anyhow::Result<Self> {
-        let context = RPCContext {
-            local_port: 2049,
-            client_addr: "localhost".to_string(),
-            auth: nfs3_types::rpc::auth_unix::default(),
-            vfs: Arc::new(memfs),
-            mount_signal: None,
-            export_name: Arc::new("/mnt".to_string()),
-            transaction_tracker: Arc::new(TransactionTracker::new(
-                Duration::from_secs(60),
-                256,
-                1024,
-            )),
-        };
-
+        let context = RPCContext::test_ctx("/mnt", Arc::new(memfs));
         let this = Self { context, io };
         Ok(this)
     }
 
     pub fn root_dir(&self) -> nfs_fh3 {
-        self.context.vfs.id_to_fh(self.context.vfs.root_dir())
+        self.context.root_dir()
     }
 
     pub async fn run(self) -> Result<(), anyhow::Error> {

--- a/crates/nfs3_tests/src/wasm_fs.rs
+++ b/crates/nfs3_tests/src/wasm_fs.rs
@@ -245,7 +245,7 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
             .map_err(|_| nfsstat3::NFS3ERR_BADHANDLE)?;
         Ok(fileid3::from_ne_bytes(id))
     }
-    async fn path_to_id(&self, path: &str) -> Result<fileid3, nfsstat3> {
+    async fn lookup_by_path(&self, path: &str) -> Result<fileid3, nfsstat3> {
         let path = Path::new(path);
         let id = self
             .id_to_path_table
@@ -431,7 +431,7 @@ mod tests {
         let id = fs.fh_to_id(&root).unwrap();
         assert_eq!(id, fs.root_dir());
 
-        let id = fs.path_to_id("/").await.unwrap();
+        let id = fs.lookup_by_path("/").await.unwrap();
         assert_eq!(id, fs.root_dir());
 
         let path = fs.id_to_path(fs.root_dir()).unwrap();

--- a/crates/nfs3_tests/src/wasm_fs.rs
+++ b/crates/nfs3_tests/src/wasm_fs.rs
@@ -421,15 +421,10 @@ mod tests {
     #[tokio::test]
     async fn test_file_id() {
         let fs = super::new_mem_fs();
-        let root = fs.id_to_fh(fs.root_dir());
-
-        let id = fs.fh_to_id(&root).unwrap();
-        assert_eq!(id, fs.root_dir());
-
         let id = fs.lookup_by_path("/").await.unwrap();
         assert_eq!(id, fs.root_dir());
 
-        let path = fs.id_to_path(fs.root_dir()).unwrap();
+        let path = fs.id_to_path(&fs.root_dir()).unwrap();
         assert_eq!(path, Path::new("/"));
     }
 

--- a/crates/nfs3_tests/src/wasm_fs.rs
+++ b/crates/nfs3_tests/src/wasm_fs.rs
@@ -249,10 +249,6 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
 
         Ok(self.symbol_to_id(id))
     }
-
-    fn serverid(&self) -> cookieverf3 {
-        cookieverf3(self.server_id.to_ne_bytes())
-    }
 }
 
 impl<FS: wasmer_vfs::FileSystem> nfs3_server::vfs::NfsFileSystem for WasmFs<FS> {

--- a/crates/nfs3_tests/src/wasm_fs.rs
+++ b/crates/nfs3_tests/src/wasm_fs.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use intaglio::Symbol;
 use nfs3_server::vfs::{
-    FileHandle, NfsFileSystem, NfsReadFileSystem, ReadDirIterator, ReadDirPlusIterator,
-    VFSCapabilities,
+    FileHandle, FileHandleU64, NfsFileSystem, NfsReadFileSystem, ReadDirIterator,
+    ReadDirPlusIterator, VFSCapabilities,
 };
 use nfs3_types::nfs3::*;
 use nfs3_types::xdr_codec::Opaque;
@@ -17,28 +17,12 @@ use crate::server;
 const MEBIBYTE: u32 = 1024 * 1024;
 const GIBIBYTE: u64 = 1024 * 1024 * 1024;
 
-pub struct WasmFsHandle {
-    id: [u8; 8],
-}
-
-impl FileHandle for WasmFsHandle {
-    fn len(&self) -> usize {
-        self.id.len()
-    }
-    fn as_bytes(&self) -> &[u8] {
-        &self.id
-    }
-    fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        bytes.try_into().ok().map(|id| Self { id })
-    }
-}
-
 #[derive(Debug)]
 pub struct WasmFs<FS> {
     fs: FS,
     id_to_path_table: intaglio::path::SymbolTable,
     server_id: u64,
-    root: fileid3,
+    root: FileHandleU64,
 }
 
 pub fn new_mem_fs() -> WasmFs<wasmer_vfs::mem_fs::FileSystem> {
@@ -51,7 +35,7 @@ pub fn new_mem_fs() -> WasmFs<wasmer_vfs::mem_fs::FileSystem> {
         fs: wasmer_vfs::mem_fs::FileSystem::default(),
         id_to_path_table,
         server_id: (0xdead_beef << 32), // keep the same server id for testing
-        root: 0,
+        root: 0.into(),
     };
 
     fs.root = fs.symbol_to_id(root);
@@ -59,11 +43,13 @@ pub fn new_mem_fs() -> WasmFs<wasmer_vfs::mem_fs::FileSystem> {
 }
 
 impl<FS> WasmFs<FS> {
-    fn symbol_to_id(&self, symbol: Symbol) -> fileid3 {
-        self.server_id | (symbol.id() as u64)
+    fn symbol_to_id(&self, symbol: Symbol) -> FileHandleU64 {
+        let id = self.server_id | (symbol.id() as u64);
+        id.into()
     }
 
-    fn id_to_path(&self, id: fileid3) -> Result<&Path, nfsstat3> {
+    fn id_to_path(&self, id: &FileHandleU64) -> Result<&Path, nfsstat3> {
+        let id = id.as_u64();
         let server_id = id & 0xFFFF_FFFF_0000_0000;
         if server_id != self.server_id {
             return Err(nfsstat3::NFS3ERR_STALE);
@@ -86,7 +72,7 @@ impl<FS> WasmFs<FS> {
         }
     }
 
-    fn make_attr(id: fileid3, metadata: &wasmer_vfs::Metadata) -> Result<fattr3, nfsstat3> {
+    fn make_attr(id: &FileHandleU64, metadata: &wasmer_vfs::Metadata) -> Result<fattr3, nfsstat3> {
         use wasmer_vfs::FileType;
 
         let file_type = match metadata.file_type() {
@@ -122,7 +108,7 @@ impl<FS> WasmFs<FS> {
             used: metadata.len(),
             rdev: specdata3::default(),
             fsid: 0,
-            fileid: id,
+            fileid: id.as_u64(),
             atime: to_nfstime3(metadata.accessed()),
             mtime: to_nfstime3(metadata.modified()),
             ctime: to_nfstime3(metadata.created()),
@@ -131,14 +117,17 @@ impl<FS> WasmFs<FS> {
         Ok(fattr)
     }
 }
-
 impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
-    type Handle = WasmFsHandle;
+    type Handle = nfs3_server::vfs::FileHandleU64;
 
-    fn root_dir(&self) -> fileid3 {
+    fn root_dir(&self) -> Self::Handle {
         self.root
     }
-    async fn lookup(&self, dirid: fileid3, filename: &filename3<'_>) -> Result<fileid3, nfsstat3> {
+    async fn lookup(
+        &self,
+        dirid: &Self::Handle,
+        filename: &filename3<'_>,
+    ) -> Result<Self::Handle, nfsstat3> {
         let path = self.id_to_path(dirid)?;
         let filename = Self::filename_to_utf8(filename)?;
 
@@ -158,7 +147,7 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
         Ok(self.symbol_to_id(id))
     }
 
-    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+    async fn getattr(&self, id: &Self::Handle) -> Result<fattr3, nfsstat3> {
         let path = self.id_to_path(id)?;
         let metadata = self.fs.metadata(path).map_err(wasm_error_to_nfsstat3)?;
         Self::make_attr(id, &metadata)
@@ -166,7 +155,7 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
 
     async fn read(
         &self,
-        id: fileid3,
+        id: &Self::Handle,
         offset: u64,
         count: u32,
     ) -> Result<(Vec<u8>, bool), nfsstat3> {
@@ -206,27 +195,27 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
 
     async fn readdir(
         &self,
-        dirid: fileid3,
-        start_after: fileid3,
+        dirid: &Self::Handle,
+        start_after: cookie3,
     ) -> Result<impl ReadDirIterator, nfsstat3> {
         Err::<ReadDirStubIterator, nfsstat3>(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     async fn readdirplus(
         &self,
-        dirid: fileid3,
-        start_after: fileid3,
+        dirid: &Self::Handle,
+        start_after: cookie3,
     ) -> Result<impl ReadDirPlusIterator, nfsstat3> {
         Err::<ReadDirStubIterator, nfsstat3>(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     /// Reads a symlink
-    async fn readlink(&self, id: fileid3) -> Result<nfspath3, nfsstat3> {
+    async fn readlink(&self, id: &Self::Handle) -> Result<nfspath3, nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     /// Get static file system Information
-    async fn fsinfo(&self, root_fileid: fileid3) -> Result<FSINFO3resok, nfsstat3> {
+    async fn fsinfo(&self, root_fileid: &Self::Handle) -> Result<FSINFO3resok, nfsstat3> {
         let dir_attr: post_op_attr = match self.getattr(root_fileid).await {
             Ok(v) => post_op_attr::Some(v),
             Err(_) => post_op_attr::None,
@@ -251,20 +240,7 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
         Ok(res)
     }
 
-    fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
-        nfs_fh3 {
-            data: Opaque::owned(id.to_ne_bytes().to_vec()),
-        }
-    }
-    fn fh_to_id(&self, id: &nfs_fh3) -> Result<fileid3, nfsstat3> {
-        let id: [u8; 8] = id
-            .data
-            .as_ref()
-            .try_into()
-            .map_err(|_| nfsstat3::NFS3ERR_BADHANDLE)?;
-        Ok(fileid3::from_ne_bytes(id))
-    }
-    async fn lookup_by_path(&self, path: &str) -> Result<fileid3, nfsstat3> {
+    async fn lookup_by_path(&self, path: &str) -> Result<Self::Handle, nfsstat3> {
         let path = Path::new(path);
         let id = self
             .id_to_path_table
@@ -280,7 +256,7 @@ impl<FS: wasmer_vfs::FileSystem> NfsReadFileSystem for WasmFs<FS> {
 }
 
 impl<FS: wasmer_vfs::FileSystem> nfs3_server::vfs::NfsFileSystem for WasmFs<FS> {
-    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+    async fn setattr(&self, id: &Self::Handle, setattr: sattr3) -> Result<fattr3, nfsstat3> {
         use wasmer_vfs::OpenOptionsConfig;
 
         let path = self.id_to_path(id)?;
@@ -329,43 +305,43 @@ impl<FS: wasmer_vfs::FileSystem> nfs3_server::vfs::NfsFileSystem for WasmFs<FS> 
         Self::make_attr(id, &metadata)
     }
 
-    async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+    async fn write(&self, id: &Self::Handle, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     async fn create(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         filename: &filename3<'_>,
         attr: sattr3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(Self::Handle, fattr3), nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     async fn create_exclusive(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         filename: &filename3<'_>,
-    ) -> Result<fileid3, nfsstat3> {
+    ) -> Result<Self::Handle, nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
     async fn mkdir(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         dirname: &filename3<'_>,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(Self::Handle, fattr3), nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
-    async fn remove(&self, dirid: fileid3, filename: &filename3<'_>) -> Result<(), nfsstat3> {
+    async fn remove(&self, dirid: &Self::Handle, filename: &filename3<'_>) -> Result<(), nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 
     async fn rename<'a>(
         &self,
-        from_dirid: fileid3,
+        from_dirid: &Self::Handle,
         from_filename: &filename3<'a>,
-        to_dirid: fileid3,
+        to_dirid: &Self::Handle,
         to_filename: &filename3<'a>,
     ) -> Result<(), nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
@@ -373,11 +349,11 @@ impl<FS: wasmer_vfs::FileSystem> nfs3_server::vfs::NfsFileSystem for WasmFs<FS> 
 
     async fn symlink<'a>(
         &self,
-        dirid: fileid3,
+        dirid: &Self::Handle,
         linkname: &filename3<'a>,
         symlink: &nfspath3<'a>,
         attr: &sattr3,
-    ) -> Result<(fileid3, fattr3), nfsstat3> {
+    ) -> Result<(Self::Handle, fattr3), nfsstat3> {
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
 }


### PR DESCRIPTION
This PR removes the existing 8-byte limitation for file identifiers in VFS implementations, allowing implementers to use up to 56 bytes for file handles. Technically, the identifier can be even longer, depending on the client’s capabilities.

Additionally, this PR eliminates all `nfs_fh3` and `fileid3` conversion methods from the `NfsReadFileSystem` trait, reducing unnecessary complexity.
