### PR TITLE
ci: remove macOS x86_64 target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,6 @@ jobs:
           os: ubuntu-latest
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-24.04-arm
-        - target: x86_64-apple-darwin
-          os: macos-latest
         - target: aarch64-apple-darwin
           os: macos-latest
 
@@ -56,8 +54,6 @@ jobs:
           os: ubuntu-latest
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-24.04-arm
-        - target: x86_64-apple-darwin
-          os: macos-latest
         - target: aarch64-apple-darwin
           os: macos-latest
 


### PR DESCRIPTION
Removed x86_64-apple-darwin target from CI workflow.