### PR TITLE
Add custom generation number for clustered NFS servers

### DIFF
--- a/crates/nfs3_server/src/tcp.rs
+++ b/crates/nfs3_server/src/tcp.rs
@@ -137,6 +137,28 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
     /// "127.0.0.1:12000". `fs` is an instance of an implementation
     /// of [`NfsFileSystem`].
     pub async fn bind(ipstr: &str, fs: T) -> io::Result<Self> {
+        Self::bind_inner(ipstr, fs, None).await
+    }
+
+    /// Create a new `NFSTcpListener` with a specific generation number.
+    ///
+    /// The generation number is embedded in file handles and used to detect
+    /// stale handles from previous server instances. When multiple NFS server
+    /// instances share the same generation number, file handles remain valid
+    /// across all instances (e.g. behind a load balancer).
+    ///
+    /// See [`FileHandleConverter::with_generation_number`] for details.
+    ///
+    /// [`FileHandleConverter::with_generation_number`]: crate::vfs::handle::FileHandleConverter::with_generation_number
+    pub async fn bind_with_generation(
+        ipstr: &str,
+        fs: T,
+        generation_number: u64,
+    ) -> io::Result<Self> {
+        Self::bind_inner(ipstr, fs, Some(generation_number)).await
+    }
+
+    async fn bind_inner(ipstr: &str, fs: T, generation_number: Option<u64>) -> io::Result<Self> {
         let (ip, port) = ipstr.split_once(':').ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::AddrNotAvailable,
@@ -158,7 +180,7 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
             for try_ip in 1u16.. {
                 let ip = generate_host_ip(try_ip);
 
-                let result = Self::bind_internal(&ip, port, arcfs.clone()).await;
+                let result = Self::bind_internal(&ip, port, arcfs.clone(), generation_number).await;
 
                 match result {
                     Err(_) => {
@@ -175,11 +197,16 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
             unreachable!(); // Does not detect automatically that loop above never terminates.
         } else {
             // Otherwise, try this.
-            Self::bind_internal(ip, port, arcfs).await
+            Self::bind_internal(ip, port, arcfs, generation_number).await
         }
     }
 
-    async fn bind_internal(ip: &str, port: u16, arcfs: Arc<T>) -> io::Result<Self> {
+    async fn bind_internal(
+        ip: &str,
+        port: u16,
+        arcfs: Arc<T>,
+        generation_number: Option<u64>,
+    ) -> io::Result<Self> {
         let ipstr = format!("{ip}:{port}");
         let listener = TcpListener::bind(&ipstr).await?;
         info!("Listening on {:?}", &ipstr);
@@ -188,6 +215,12 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
             SocketAddr::V4(s) => s.port(),
             SocketAddr::V6(s) => s.port(),
         };
+
+        let file_handle_converter = generation_number.map_or_else(
+            crate::vfs::handle::FileHandleConverter::new,
+            crate::vfs::handle::FileHandleConverter::with_generation_number,
+        );
+
         Ok(Self {
             listener,
             port,
@@ -196,7 +229,7 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
             export_name: Arc::from("/".to_string()),
             transaction_tracker: Self::new_transaction_tracker(),
             stop_notify: Arc::new(tokio::sync::Notify::new()),
-            file_handle_converter: crate::vfs::handle::FileHandleConverter::new(),
+            file_handle_converter,
         })
     }
 

--- a/crates/nfs3_server/src/vfs/handle.rs
+++ b/crates/nfs3_server/src/vfs/handle.rs
@@ -108,6 +108,16 @@ impl FileHandleConverter {
             .expect("failed to get system time")
             .as_millis() as u64;
 
+        Self::with_generation_number(generation_number)
+    }
+
+    /// Creates a `FileHandleConverter` with a specific generation number.
+    ///
+    /// Use this when multiple NFS server instances need to share the same
+    /// generation number so that file handles remain valid across all
+    /// instances (e.g. behind a load balancer).
+    #[must_use]
+    pub const fn with_generation_number(generation_number: u64) -> Self {
         Self {
             generation_number,
             generation_number_le: generation_number.to_le_bytes(),
@@ -208,6 +218,59 @@ mod tests {
 
         let converted_handle = converter.fh_from_nfs::<TestHandle<3>>(&nfs_handle).unwrap();
         assert_eq!(converted_handle, handle);
+    }
+
+    #[test]
+    fn test_with_generation_number_round_trip() {
+        let converter = FileHandleConverter::with_generation_number(12345);
+        let handle = TestHandle { id: [1, 2, 3] };
+        let nfs_handle = converter.fh_to_nfs(&handle);
+
+        assert_eq!(nfs_handle.data[0..8], 12345u64.to_le_bytes());
+
+        let round_tripped = converter.fh_from_nfs::<TestHandle<3>>(&nfs_handle).unwrap();
+        assert_eq!(round_tripped, handle);
+    }
+
+    #[test]
+    fn test_with_generation_number_shared_across_instances() {
+        // Two converters with the same generation (simulating cluster nodes)
+        // must accept each other's handles.
+        let node_a = FileHandleConverter::with_generation_number(42);
+        let node_b = FileHandleConverter::with_generation_number(42);
+
+        let handle = TestHandle { id: [7, 8, 9] };
+        let nfs_handle = node_a.fh_to_nfs(&handle);
+
+        let decoded = node_b.fh_from_nfs::<TestHandle<3>>(&nfs_handle).unwrap();
+        assert_eq!(decoded, handle);
+    }
+
+    #[test]
+    fn test_with_generation_number_stale_vs_badhandle() {
+        let converter = FileHandleConverter::with_generation_number(1000);
+        let handle = TestHandle { id: [1, 2, 3] };
+        let nfs_handle = converter.fh_to_nfs(&handle);
+
+        // Newer generation → STALE (handle is from an older server)
+        let newer = FileHandleConverter::with_generation_number(2000);
+        assert_eq!(
+            newer.fh_from_nfs::<TestHandle<3>>(&nfs_handle),
+            Err(nfsstat3::NFS3ERR_STALE)
+        );
+
+        // Older generation → BADHANDLE (handle is from a future server, unexpected)
+        let older = FileHandleConverter::with_generation_number(500);
+        assert_eq!(
+            older.fh_from_nfs::<TestHandle<3>>(&nfs_handle),
+            Err(nfsstat3::NFS3ERR_BADHANDLE)
+        );
+    }
+
+    #[test]
+    fn test_with_generation_number_verf() {
+        let converter = FileHandleConverter::with_generation_number(12345);
+        assert_eq!(converter.verf().0, 12345u64.to_le_bytes());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `FileHandleConverter::with_generation_number(u64)` public constructor
- Add `NFSTcpListener::bind_with_generation(ipstr, fs, generation_number)` method
- Existing `bind()` and `new()` APIs unchanged (backwards compatible)

## Motivation

When multiple NFS server instances run behind a load balancer, each generates its own timestamp-based generation number via `FileHandleConverter::new()`. If a client connection moves to a different instance, all file handles are rejected as `NFS3ERR_STALE` because the generation numbers differ.

The new API allows passing a shared generation number (e.g. derived from a cluster secret) so that file handles remain valid across all instances.

## Changes

**`vfs/handle.rs`**:
- `FileHandleConverter::with_generation_number(u64)` — `pub const fn` constructor
- 4 new tests: round-trip, cross-instance sharing, STALE vs BADHANDLE error classification, verf output

**`tcp.rs`**:
- `NFSTcpListener::bind_with_generation()` — public async method
- `bind_inner()` — shared implementation accepting `Option<u64>`
- `bind_internal()` — updated to accept optional generation number
- `bind()` unchanged, delegates to `bind_inner(..., None)`