### PR TITLE
feat(nfs3_server)!: add support for unstable writes/commit in NfsFileSystem trait

### DIFF
--- a/crates/cargo_nfs3_server/src/mirror/mod.rs
+++ b/crates/cargo_nfs3_server/src/mirror/mod.rs
@@ -452,6 +452,11 @@ impl NfsFileSystem for Fs {
         let fattr = self.getattr(&link_id).await?;
         Ok((link_id, fattr))
     }
+
+    async fn commit(&self, _id: &Self::Handle, _offset: u64, _count: u32) -> Result<(), nfsstat3> {
+        // at the moment, mirror fs supports only synchronous writes, there is nothing to commit
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/cargo_nfs3_server/src/mirror/mod.rs
+++ b/crates/cargo_nfs3_server/src/mirror/mod.rs
@@ -11,7 +11,7 @@ use iterator_cache::{IteratorCache, IteratorCacheCleaner};
 use nfs3_server::fs_util::metadata_to_fattr3;
 use nfs3_server::nfs3_types::nfs3::{
     createverf3, fattr3, filename3, nfspath3, nfsstat3, sattr3, set_gid3, set_mode3, set_size3,
-    set_uid3,
+    set_uid3, stable_how,
 };
 use nfs3_server::vfs::{
     FileHandleU64, NfsFileSystem, NfsReadFileSystem, ReadDirIterator, ReadDirPlusIterator,
@@ -227,7 +227,13 @@ impl NfsFileSystem for Fs {
         self.getattr(id).await
     }
 
-    async fn write(&self, id: &Self::Handle, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+    async fn write(
+        &self,
+        id: &Self::Handle,
+        offset: u64,
+        data: &[u8],
+        _stable: stable_how,
+    ) -> Result<(fattr3, stable_how), nfsstat3> {
         let path = self.path(*id)?;
 
         // Check if it's a regular file
@@ -251,7 +257,8 @@ impl NfsFileSystem for Fs {
         .await
         .map_err(map_io_error)?;
 
-        self.getattr(id).await
+        let attr = self.getattr(id).await?;
+        Ok((attr, stable_how::FILE_SYNC))
     }
 
     async fn create(

--- a/crates/nfs3_server/examples/mirrorfs.rs
+++ b/crates/nfs3_server/examples/mirrorfs.rs
@@ -712,6 +712,10 @@ impl NfsFileSystem for MirrorFs {
         .await
         .map(|(id, attr)| (FileHandleU64::new(id), attr))
     }
+
+    async fn commit(&self, _id: &Self::Handle, _offset: u64, _count: u32) -> Result<(), nfsstat3> {
+        Ok(())
+    }
 }
 
 struct MirrorFsIterator {

--- a/crates/nfs3_server/examples/mirrorfs.rs
+++ b/crates/nfs3_server/examples/mirrorfs.rs
@@ -15,6 +15,7 @@ use nfs3_server::fs_util::{
 };
 use nfs3_server::nfs3_types::nfs3::{
     cookie3, createverf3, fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, sattr3,
+    stable_how,
 };
 use nfs3_server::tcp::{NFSTcp, NFSTcpListener};
 use nfs3_server::vfs::{
@@ -503,7 +504,13 @@ impl NfsFileSystem for MirrorFs {
         }
         Ok(metadata_to_fattr3(id, &metadata))
     }
-    async fn write(&self, id: &Self::Handle, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+    async fn write(
+        &self,
+        id: &Self::Handle,
+        offset: u64,
+        data: &[u8],
+        _stable: stable_how,
+    ) -> Result<(fattr3, stable_how), nfsstat3> {
         let id = id.as_u64();
         let fsmap = self.fsmap.read().await;
         let ent = fsmap.find_entry(id)?;
@@ -517,22 +524,22 @@ impl NfsFileSystem for MirrorFs {
             .open(&path)
             .await
             .map_err(|e| {
-                debug!("Unable to open {:?}", e);
+                debug!("Unable to open: {e}");
                 nfsstat3::NFS3ERR_IO
             })?;
         f.seek(SeekFrom::Start(offset)).await.map_err(|e| {
-            debug!("Unable to seek {:?}", e);
+            debug!("Unable to seek: {e}");
             nfsstat3::NFS3ERR_IO
         })?;
         f.write_all(data).await.map_err(|e| {
-            debug!("Unable to write {:?}", e);
+            debug!("Unable to write: {e}");
             nfsstat3::NFS3ERR_IO
         })?;
-        debug!("write to {:?} {:?} {:?}", path, offset, data.len());
+        debug!("write to {:?} {offset} {:?}", path.display(), data.len());
         let _ = f.flush().await;
         let _ = f.sync_all().await;
         let meta = f.metadata().await.or(Err(nfsstat3::NFS3ERR_IO))?;
-        Ok(metadata_to_fattr3(id, &meta))
+        Ok((metadata_to_fattr3(id, &meta), stable_how::FILE_SYNC))
     }
 
     async fn create(

--- a/crates/nfs3_server/src/memfs/mod.rs
+++ b/crates/nfs3_server/src/memfs/mod.rs
@@ -831,6 +831,11 @@ impl NfsFileSystem for MemFs {
         tracing::warn!("symlink not implemented");
         Err(nfsstat3::NFS3ERR_NOTSUPP)
     }
+
+    async fn commit(&self, _id: &FileHandleU64, _offset: u64, _count: u32) -> Result<(), nfsstat3> {
+        // In-memory filesystem: all writes are immediately "committed".
+        Ok(())
+    }
 }
 
 struct MemFsIterator {

--- a/crates/nfs3_server/src/memfs/mod.rs
+++ b/crates/nfs3_server/src/memfs/mod.rs
@@ -758,12 +758,14 @@ impl NfsFileSystem for MemFs {
         id: &FileHandleU64,
         offset: u64,
         data: &[u8],
-    ) -> Result<fattr3, nfsstat3> {
+        _stable: nfs::stable_how, // MemFs writes are always `FILE_SYNC`
+    ) -> Result<(fattr3, nfs::stable_how), nfsstat3> {
         let mut fs = self.fs.write().expect("lock is poisoned");
 
         let entry = fs.get_mut(*id).ok_or(nfsstat3::NFS3ERR_NOENT)?;
         let file = entry.as_file_mut().map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
-        file.write(offset, data)
+        let attr = file.write(offset, data)?;
+        Ok((attr, nfs::stable_how::FILE_SYNC))
     }
 
     async fn create(

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -60,7 +60,8 @@ where
         NFSPROC3_MKDIR => handle(context, message, nfsproc3_mkdir).await,
         NFSPROC3_SYMLINK => handle(context, message, nfsproc3_symlink).await,
         NFSPROC3_READLINK => handle(context, message, nfsproc3_readlink).await,
-        NFSPROC3_MKNOD | NFSPROC3_LINK | NFSPROC3_COMMIT => {
+        NFSPROC3_COMMIT => handle(context, message, nfsproc3_commit).await,
+        NFSPROC3_MKNOD | NFSPROC3_LINK => {
             warn!("Unimplemented message {proc}");
             message.into_error_reply(accept_stat_data::PROC_UNAVAIL)
         }
@@ -569,6 +570,46 @@ where
                         before,
                         after: post_op_attr::None,
                     },
+                },
+            ))
+        }
+    }
+}
+
+async fn nfsproc3_commit<T>(context: RPCContext<T>, xid: u32, args: COMMIT3args) -> COMMIT3res
+where
+    T: NfsFileSystem,
+{
+    let id = match context.file_handle_converter.fh_from_nfs(&args.file) {
+        Ok(id) => id,
+        Err(stat) => {
+            warn!("cannot resolve fh: {stat}");
+            return COMMIT3res::Err((
+                stat,
+                COMMIT3resfail {
+                    file_wcc: wcc_data::default(),
+                },
+            ));
+        }
+    };
+    match context.vfs.commit(&id, args.offset, args.count).await {
+        Ok(()) => {
+            let file_attr = nfs_option_from_result(context.vfs.getattr(&id).await);
+            debug!("commit success {xid}");
+            COMMIT3res::Ok(COMMIT3resok {
+                file_wcc: wcc_data {
+                    before: pre_op_attr::None,
+                    after: file_attr,
+                },
+                verf: context.file_handle_converter.verf(),
+            })
+        }
+        Err(stat) => {
+            error!("commit error {xid} --> {stat}");
+            COMMIT3res::Err((
+                stat,
+                COMMIT3resfail {
+                    file_wcc: wcc_data::default(),
                 },
             ))
         }

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -546,18 +546,18 @@ where
 
     match context
         .vfs
-        .write(&id, write3args.offset, &write3args.data)
+        .write(&id, write3args.offset, &write3args.data, write3args.stable)
         .await
     {
-        Ok(fattr) => {
-            debug!("write success {xid} --> {fattr:?}");
+        Ok((fattr, committed)) => {
+            debug!("write success {xid} --> {fattr:?}, committed: {committed}");
             WRITE3res::Ok(WRITE3resok {
                 file_wcc: wcc_data {
                     before,
                     after: post_op_attr::Some(fattr),
                 },
                 count: write3args.count,
-                committed: stable_how::FILE_SYNC,
+                committed,
                 verf: context.file_handle_converter.verf(),
             })
         }

--- a/crates/nfs3_server/src/nfs_handlers.rs
+++ b/crates/nfs3_server/src/nfs_handlers.rs
@@ -592,24 +592,25 @@ where
             ));
         }
     };
+    let before = get_wcc_attr(&context, &id)
+        .await
+        .map_or(pre_op_attr::None, pre_op_attr::Some);
     match context.vfs.commit(&id, args.offset, args.count).await {
         Ok(()) => {
-            let file_attr = nfs_option_from_result(context.vfs.getattr(&id).await);
+            let after = nfs_option_from_result(context.vfs.getattr(&id).await);
             debug!("commit success {xid}");
             COMMIT3res::Ok(COMMIT3resok {
-                file_wcc: wcc_data {
-                    before: pre_op_attr::None,
-                    after: file_attr,
-                },
+                file_wcc: wcc_data { before, after },
                 verf: context.file_handle_converter.verf(),
             })
         }
         Err(stat) => {
+            let after = nfs_option_from_result(context.vfs.getattr(&id).await);
             error!("commit error {xid} --> {stat}");
             COMMIT3res::Err((
                 stat,
                 COMMIT3resfail {
-                    file_wcc: wcc_data::default(),
+                    file_wcc: wcc_data { before, after },
                 },
             ))
         }

--- a/crates/nfs3_server/src/tcp.rs
+++ b/crates/nfs3_server/src/tcp.rs
@@ -146,10 +146,6 @@ impl<T: NfsFileSystem + 'static> NFSTcpListener<T> {
     /// stale handles from previous server instances. When multiple NFS server
     /// instances share the same generation number, file handles remain valid
     /// across all instances (e.g. behind a load balancer).
-    ///
-    /// See [`FileHandleConverter::with_generation_number`] for details.
-    ///
-    /// [`FileHandleConverter::with_generation_number`]: crate::vfs::handle::FileHandleConverter::with_generation_number
     pub async fn bind_with_generation(
         ipstr: &str,
         fs: T,

--- a/crates/nfs3_server/src/vfs/adapters/mod.rs
+++ b/crates/nfs3_server/src/vfs/adapters/mod.rs
@@ -107,7 +107,8 @@ where
         _id: &Self::Handle,
         _offset: u64,
         _data: &[u8],
-    ) -> Result<fattr3, nfsstat3> {
+        _stable: nfs3_types::nfs3::stable_how,
+    ) -> Result<(fattr3, nfs3_types::nfs3::stable_how), nfsstat3> {
         Err(nfsstat3::NFS3ERR_ROFS)
     }
 

--- a/crates/nfs3_server/src/vfs/adapters/mod.rs
+++ b/crates/nfs3_server/src/vfs/adapters/mod.rs
@@ -164,6 +164,10 @@ where
     ) -> Result<(Self::Handle, fattr3), nfsstat3> {
         Err(nfsstat3::NFS3ERR_ROFS)
     }
+
+    async fn commit(&self, _id: &Self::Handle, _offset: u64, _count: u32) -> Result<(), nfsstat3> {
+        Err(nfsstat3::NFS3ERR_ROFS)
+    }
 }
 
 #[derive(Debug)]

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -30,7 +30,7 @@ pub use iterator::*;
 
 use crate::nfs3_types::nfs3::{
     FSF3_CANSETTIME, FSF3_HOMOGENEOUS, FSF3_SYMLINK, FSINFO3resok as fsinfo3, createverf3, fattr3,
-    filename3, nfspath3, nfsstat3, nfstime3, post_op_attr, sattr3,
+    filename3, nfspath3, nfsstat3, nfstime3, post_op_attr, sattr3, stable_how,
 };
 use crate::units::{GIBIBYTE, MEBIBYTE};
 use crate::vfs::adapters::ReadDirPlusToReadDir;
@@ -186,11 +186,29 @@ pub trait NfsFileSystem: NfsReadFileSystem {
         setattr: sattr3,
     ) -> impl Future<Output = Result<fattr3, nfsstat3>> + Send;
 
-    /// Writes the contents of a file returning (bytes, EOF)
-    /// Note that offset/count may go past the end of the file and that
-    /// in that case, the file is extended.
-    /// If not supported due to readonly file system
-    /// this should return `Err(nfsstat3::NFS3ERR_ROFS)`
+    /// Writes the contents of a file.
+    ///
+    /// If the offset and count go past the end of the file, the file is extended.
+    /// If not supported due to readonly file system this should return
+    /// `Err(nfsstat3::NFS3ERR_ROFS)`
+    ///
+    /// # Returns
+    ///
+    /// On success, returns `(fattr3, stable_how)` where:
+    /// - [`fattr3`] contains the updated file attributes after the write.
+    /// - [`stable_how`] reflects the level of stability actually achieved, which must be equal to
+    ///   or greater than the requested `stable` level.
+    ///
+    /// # `stable` parameter
+    ///
+    /// - [`stable_how::FILE_SYNC`]: all data and metadata must be committed to stable storage
+    ///   before returning. Any other behavior is a protocol violation.
+    /// - [`stable_how::DATA_SYNC`]: all data and enough metadata to retrieve it must be committed
+    ///   before returning. Could be implemented identically to `FILE_SYNC`.
+    /// - [`stable_how::UNSTABLE`]: the server may defer committing any data or metadata.
+    ///   Uncommitted data can later be flushed via [`commit`]. Usually, clients will send a series
+    ///   of UNSTABLE writes followed by a [`commit`], so servers can optimize for this case by
+    ///   deferring the actual disk writes until the [`commit`] is received.
     ///
     /// # `NFS3ERR_INVAL`:
     ///
@@ -203,7 +221,8 @@ pub trait NfsFileSystem: NfsReadFileSystem {
         id: &Self::Handle,
         offset: u64,
         data: &[u8],
-    ) -> impl Future<Output = Result<fattr3, nfsstat3>> + Send;
+        stable: stable_how,
+    ) -> impl Future<Output = Result<(fattr3, stable_how), nfsstat3>> + Send;
 
     /// Creates a file with the following attributes.
     /// If not supported due to readonly file system
@@ -290,23 +309,10 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// The default implementation returns [`nfsstat3::NFS3ERR_NOTSUPP`].
     /// Implementations should override this to flush written data to disk,
     /// or return `Ok(())` if all writes are already [`stable_how::FILE_SYNC`].
-    // TODO: remove the default implementation with the next breaking release
-    #[expect(
-        unused_variables,
-        reason = "trait methods should have proper arguments' names"
-    )]
     fn commit(
         &self,
         id: &Self::Handle,
         offset: u64,
         count: u32,
-    ) -> impl Future<Output = Result<(), nfsstat3>> + Send {
-        async move {
-            if self.capabilities() == VFSCapabilities::ReadOnly {
-                Err(nfsstat3::NFS3ERR_ROFS)
-            } else {
-                Err(nfsstat3::NFS3ERR_NOTSUPP)
-            }
-        }
-    }ss
+    ) -> impl Future<Output = Result<(), nfsstat3>> + Send;
 }

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -206,9 +206,10 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     /// - [`stable_how::DATA_SYNC`]: all data and enough metadata to retrieve it must be committed
     ///   before returning. Could be implemented identically to `FILE_SYNC`.
     /// - [`stable_how::UNSTABLE`]: the server may defer committing any data or metadata.
-    ///   Uncommitted data can later be flushed via [`commit`]. Usually, clients will send a series
-    ///   of UNSTABLE writes followed by a [`commit`], so servers can optimize for this case by
-    ///   deferring the actual disk writes until the [`commit`] is received.
+    ///   Uncommitted data can later be flushed via [`commit`][NfsFileSystem::commit]. Usually,
+    ///   clients will send a series of UNSTABLE writes followed by a
+    ///   [`commit`][NfsFileSystem::commit], so servers can optimize for this case by deferring the
+    ///   actual disk writes until the [`commit`][NfsFileSystem::commit] is received.
     ///
     /// # `NFS3ERR_INVAL`:
     ///

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -305,10 +305,6 @@ pub trait NfsFileSystem: NfsReadFileSystem {
     ///
     /// `offset` and `count` indicate the region to commit. If `count` is 0
     /// the entire file should be committed.
-    ///
-    /// The default implementation returns [`nfsstat3::NFS3ERR_NOTSUPP`].
-    /// Implementations should override this to flush written data to disk,
-    /// or return `Ok(())` if all writes are already [`stable_how::FILE_SYNC`].
     fn commit(
         &self,
         id: &Self::Handle,

--- a/crates/nfs3_server/src/vfs/mod.rs
+++ b/crates/nfs3_server/src/vfs/mod.rs
@@ -281,4 +281,32 @@ pub trait NfsFileSystem: NfsReadFileSystem {
         symlink: &nfspath3<'a>,
         attr: &sattr3,
     ) -> impl Future<Output = Result<(Self::Handle, fattr3), nfsstat3>> + Send;
+
+    /// Commits previously written data to stable storage.
+    ///
+    /// `offset` and `count` indicate the region to commit. If `count` is 0
+    /// the entire file should be committed.
+    ///
+    /// The default implementation returns [`nfsstat3::NFS3ERR_NOTSUPP`].
+    /// Implementations should override this to flush written data to disk,
+    /// or return `Ok(())` if all writes are already [`stable_how::FILE_SYNC`].
+    // TODO: remove the default implementation with the next breaking release
+    #[expect(
+        unused_variables,
+        reason = "trait methods should have proper arguments' names"
+    )]
+    fn commit(
+        &self,
+        id: &Self::Handle,
+        offset: u64,
+        count: u32,
+    ) -> impl Future<Output = Result<(), nfsstat3>> + Send {
+        async move {
+            if self.capabilities() == VFSCapabilities::ReadOnly {
+                Err(nfsstat3::NFS3ERR_ROFS)
+            } else {
+                Err(nfsstat3::NFS3ERR_NOTSUPP)
+            }
+        }
+    }ss
 }

--- a/crates/nfs3_tests/src/bin/test_mirror_fs/readonly.rs
+++ b/crates/nfs3_tests/src/bin/test_mirror_fs/readonly.rs
@@ -1079,10 +1079,9 @@ pub async fn commit_readonly_error(ctx: &mut TestContext, subdir: PathBuf, subdi
         .await;
 
     match commit_result {
-        Err(nfs3_client::error::Error::Rpc(nfs3_client::error::RpcError::ProcUnavail)) => {}
+        Ok(COMMIT3res::Err((nfsstat3::NFS3ERR_ROFS, _))) => {}
         _ => panic!(
-            "Expected RpcError::ProcUnavail error for commit on readonly filesystem, got: \
-             {commit_result:?}"
+            "Expected NFS3ERR_ROFS error for commit on readonly filesystem, got: {commit_result:?}"
         ),
     }
 }

--- a/crates/nfs3_tests/src/bin/test_mirror_fs/readwrite.rs
+++ b/crates/nfs3_tests/src/bin/test_mirror_fs/readwrite.rs
@@ -511,18 +511,8 @@ pub async fn commit_writes(ctx: &mut TestContext, subdir: PathBuf, subdir_fh: nf
         })
         .await;
 
-    // Commit may not be supported - handle both procedure unavailable and result errors
-    match commit_res {
-        Err(e) if e.to_string().contains("Procedure unavailable") => {
-            // Commit not supported by this filesystem - this is OK
-        }
-        Ok(commit_result) => {
-            if let COMMIT3res::Ok(resok) = commit_result {
-                let attrs = resok.file_wcc.after.unwrap();
-                assert_attributes_match(&attrs, &file_path, ftype3::NF3REG)
-                    .expect("commit file attributes do not match filesystem");
-            }
-        }
-        Err(e) => panic!("Commit operation failed: {}", e),
-    }
+    let resok = commit_res.expect("commit call failed").unwrap();
+    let attrs = resok.file_wcc.after.unwrap();
+    assert_attributes_match(&attrs, &file_path, ftype3::NF3REG)
+        .expect("commit file attributes do not match filesystem");
 }

--- a/crates/nfs3_tests/src/bin/test_mirror_fs/readwrite.rs
+++ b/crates/nfs3_tests/src/bin/test_mirror_fs/readwrite.rs
@@ -512,6 +512,8 @@ pub async fn commit_writes(ctx: &mut TestContext, subdir: PathBuf, subdir_fh: nf
         .await;
 
     let resok = commit_res.expect("commit call failed").unwrap();
+    let before_wcc = resok.file_wcc.before.unwrap();
+    assert_eq!(before_wcc.size, COMMIT_CONTENT.len() as u64);
     let attrs = resok.file_wcc.after.unwrap();
     assert_attributes_match(&attrs, &file_path, ftype3::NF3REG)
         .expect("commit file attributes do not match filesystem");

--- a/crates/nfs3_tests/tests/base_tests.rs
+++ b/crates/nfs3_tests/tests/base_tests.rs
@@ -207,6 +207,8 @@ async fn test_write() -> Result<(), anyhow::Error> {
 
     tracing::info!("{write:?}");
     assert_eq!(write.count, COUNT as u32);
+    // MemFs always commits synchronously regardless of the requested stable level.
+    assert_eq!(write.committed, stable_how::FILE_SYNC);
 
     // Additional check to verify the file was written correctly
     let read = client
@@ -703,24 +705,81 @@ async fn test_pathconf() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_commit() -> Result<(), anyhow::Error> {
-    use nfs3_client::error::*;
-
     let mut client = TestContext::setup();
     let root = client.root_dir().clone();
 
+    // MemFs commits immediately; COMMIT on the root dir should succeed.
     let commit = client
         .commit(&COMMIT3args {
             file: root.clone(),
             offset: 0,
             count: 1024,
         })
-        .await;
+        .await?
+        .unwrap();
 
-    if let Err(Error::Rpc(RpcError::ProcUnavail)) = commit {
-        tracing::info!("Server does not support COMMIT yet");
-    } else {
-        panic!("Expected ProcUnavail error");
-    }
+    tracing::info!("{commit:?}");
+
+    client.shutdown().await
+}
+
+#[tokio::test]
+async fn test_unstable_write_then_commit() -> Result<(), anyhow::Error> {
+    const DATA: &[u8] = b"unstable write data";
+
+    let mut client = TestContext::setup();
+    let root = client.root_dir().clone();
+
+    let create = client
+        .create(&CREATE3args {
+            where_: diropargs3 {
+                dir: root.clone(),
+                name: b"unstable.txt".as_slice().into(),
+            },
+            how: createhow3::UNCHECKED(sattr3::default()),
+        })
+        .await?
+        .unwrap();
+
+    let file_handle = create.obj.unwrap();
+
+    let write = client
+        .write(&WRITE3args {
+            file: file_handle.clone(),
+            offset: 0,
+            count: DATA.len() as u32,
+            stable: stable_how::UNSTABLE,
+            data: Opaque::borrowed(DATA),
+        })
+        .await?
+        .unwrap();
+
+    assert_eq!(write.count, DATA.len() as u32);
+    assert_eq!(write.committed, stable_how::FILE_SYNC); // MemFs ignores the requested stable level and always commits synchronously.
+
+    // COMMIT should succeed regardless.
+    let commit = client
+        .commit(&COMMIT3args {
+            file: file_handle.clone(),
+            offset: 0,
+            count: 1024,
+        })
+        .await?
+        .unwrap();
+
+    tracing::info!("{commit:?}");
+
+    // Data must be readable after commit.
+    let read = client
+        .read(&READ3args {
+            file: file_handle.clone(),
+            offset: 0,
+            count: DATA.len() as u32,
+        })
+        .await?
+        .unwrap();
+
+    assert_eq!(read.data.as_ref(), DATA);
 
     client.shutdown().await
 }

--- a/crates/nfs3_tests/tests/base_tests.rs
+++ b/crates/nfs3_tests/tests/base_tests.rs
@@ -768,6 +768,7 @@ async fn test_unstable_write_then_commit() -> Result<(), anyhow::Error> {
         .unwrap();
 
     tracing::info!("{commit:?}");
+    assert_eq!(write.verf, commit.verf);
 
     // Data must be readable after commit.
     let read = client

--- a/crates/nfs3_tests/tests/base_tests.rs
+++ b/crates/nfs3_tests/tests/base_tests.rs
@@ -52,9 +52,10 @@ async fn test_getattr_bad_handle() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{getattr:?}");
-    if !matches!(getattr, Nfs3Result::Err((nfsstat3::NFS3ERR_BADHANDLE, _))) {
-        panic!("Expected NFS3ERR_BADHANDLE error");
-    }
+    assert!(
+        matches!(getattr, Nfs3Result::Err((nfsstat3::NFS3ERR_BADHANDLE, _))),
+        "Expected NFS3ERR_BADHANDLE error"
+    );
 
     client.shutdown().await
 }
@@ -107,11 +108,10 @@ async fn test_readlink() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readlink:?}");
-    if matches!(readlink, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTSUPP, _))) {
-        tracing::info!("not supported by current implementation");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(readlink, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTSUPP, _))),
+        "Expected NFS3ERR_NOTSUPP error"
+    );
 
     client.shutdown().await
 }
@@ -130,11 +130,10 @@ async fn test_read_dir_as_file() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{read:?}");
-    if matches!(read, Nfs3Result::Err((nfsstat3::NFS3ERR_ISDIR, _))) {
-        tracing::info!("not supported by current implementation");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(read, Nfs3Result::Err((nfsstat3::NFS3ERR_ISDIR, _))),
+        "Expected NFS3ERR_ISDIR error"
+    );
 
     client.shutdown().await
 }
@@ -300,11 +299,10 @@ async fn test_create_exclusive() -> Result<(), anyhow::Error> {
         })
         .await?;
 
-    if matches!(create, Nfs3Result::Err((nfsstat3::NFS3ERR_EXIST, _))) {
-        tracing::info!("file already exists, as expected");
-    } else {
-        panic!("Expected NFS3ERR_EXIST error");
-    }
+    assert!(
+        matches!(create, Nfs3Result::Err((nfsstat3::NFS3ERR_EXIST, _))),
+        "Expected NFS3ERR_EXIST error"
+    );
 
     // recreate the file with the same verifier, should succeed
     let _create = client
@@ -365,11 +363,10 @@ async fn test_symlink() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{symlink:?}");
-    if matches!(symlink, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTSUPP, _))) {
-        tracing::info!("not supported by current implementation yet");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(symlink, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTSUPP, _))),
+        "Expected NFS3ERR_NOTSUPP error"
+    );
 
     client.shutdown().await
 }
@@ -392,11 +389,10 @@ async fn test_mknod() -> Result<(), anyhow::Error> {
         .await;
 
     tracing::info!("{mknod:?}");
-    if matches!(mknod, Err(Error::Rpc(RpcError::ProcUnavail))) {
-        tracing::info!("not supported by nfs3_server yet");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(mknod, Err(Error::Rpc(RpcError::ProcUnavail))),
+        "Expected ProcUnavail error"
+    );
 
     client.shutdown().await
 }
@@ -435,9 +431,10 @@ async fn test_remove_noent() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{remove:?}");
-    if !matches!(remove, Nfs3Result::Err((nfsstat3::NFS3ERR_NOENT, _))) {
-        panic!("Expected NFS3ERR_NOENT error");
-    }
+    assert!(
+        matches!(remove, Nfs3Result::Err((nfsstat3::NFS3ERR_NOENT, _))),
+        "Expected NFS3ERR_NOENT error"
+    );
 
     client.shutdown().await
 }
@@ -457,9 +454,10 @@ async fn test_rmdir_noent() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rmdir:?}");
-    if !matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_NOENT, _))) {
-        panic!("Expected NFS3ERR_NOENT error");
-    }
+    assert!(
+        matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_NOENT, _))),
+        "Expected NFS3ERR_NOENT error"
+    );
 
     client.shutdown().await
 }
@@ -479,9 +477,10 @@ async fn test_rmdir_notempty() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rmdir:?}");
-    if !matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTEMPTY, _))) {
-        panic!("Expected NFS3ERR_NOTEMPTY error");
-    }
+    assert!(
+        matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTEMPTY, _))),
+        "Expected NFS3ERR_NOTEMPTY error"
+    );
 
     client.shutdown().await
 }
@@ -533,11 +532,10 @@ async fn test_link() -> Result<(), anyhow::Error> {
         })
         .await;
 
-    if let Err(Error::Rpc(RpcError::ProcUnavail)) = link {
-        tracing::info!("Server does not support COMMIT yet");
-    } else {
-        panic!("Expected ProcUnavail error");
-    }
+    assert!(
+        matches!(link, Err(Error::Rpc(RpcError::ProcUnavail))),
+        "Expected ProcUnavail error"
+    );
 
     client.shutdown().await
 }
@@ -576,9 +574,10 @@ async fn test_readdir_too_small() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readdir:?}");
-    if !matches!(readdir, Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))) {
-        panic!("Expected NFS3ERR_TOOSMALL error");
-    }
+    assert!(
+        matches!(readdir, Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))),
+        "Expected NFS3ERR_TOOSMALL error"
+    );
 
     client.shutdown().await
 }
@@ -619,12 +618,13 @@ async fn test_readdirplus_dircount_too_small() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readdirplus:?}");
-    if !matches!(
-        readdirplus,
-        Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
-    ) {
-        panic!("Expected NFS3ERR_TOOSMALL error");
-    }
+    assert!(
+        matches!(
+            readdirplus,
+            Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
+        ),
+        "Expected NFS3ERR_TOOSMALL error"
+    );
 
     client.shutdown().await
 }
@@ -645,12 +645,13 @@ async fn test_readdirplus_maxcount_too_small() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readdirplus:?}");
-    if !matches!(
-        readdirplus,
-        Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
-    ) {
-        panic!("Expected NFS3ERR_TOOSMALL error");
-    }
+    assert!(
+        matches!(
+            readdirplus,
+            Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
+        ),
+        "Expected NFS3ERR_TOOSMALL error"
+    );
 
     client.shutdown().await
 }
@@ -769,6 +770,12 @@ async fn test_unstable_write_then_commit() -> Result<(), anyhow::Error> {
 
     tracing::info!("{commit:?}");
     assert_eq!(write.verf, commit.verf);
+
+    let before_wcc = commit.file_wcc.before.unwrap();
+    assert_eq!(before_wcc.size, DATA.len() as u64);
+    let after_attr = commit.file_wcc.after.unwrap();
+    assert_eq!(after_attr.type_, ftype3::NF3REG);
+    assert_eq!(after_attr.size, DATA.len() as u64);
 
     // Data must be readable after commit.
     let read = client

--- a/crates/nfs3_tests/tests/rename_tests.rs
+++ b/crates/nfs3_tests/tests/rename_tests.rs
@@ -53,9 +53,10 @@ async fn test_rename_noent() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rename:?}");
-    if !matches!(rename, Nfs3Result::Err((nfsstat3::NFS3ERR_NOENT, _))) {
-        panic!("Expected NFS3ERR_NOENT error");
-    }
+    assert!(
+        matches!(rename, Nfs3Result::Err((nfsstat3::NFS3ERR_NOENT, _))),
+        "Expected NFS3ERR_NOENT error"
+    );
 
     client.shutdown().await
 }

--- a/crates/nfs3_tests/tests/ro_tests.rs
+++ b/crates/nfs3_tests/tests/ro_tests.rs
@@ -77,9 +77,10 @@ async fn test_getattr_bad_handle() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{getattr:?}");
-    if !matches!(getattr, Nfs3Result::Err((nfsstat3::NFS3ERR_BADHANDLE, _))) {
-        panic!("Expected NFS3ERR_BADHANDLE error");
-    }
+    assert!(
+        matches!(getattr, Nfs3Result::Err((nfsstat3::NFS3ERR_BADHANDLE, _))),
+        "Expected NFS3ERR_BADHANDLE error"
+    );
 
     client.shutdown().await
 }
@@ -112,9 +113,10 @@ async fn test_setattr() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{setattr:?}");
-    if !matches!(setattr, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(setattr, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -148,11 +150,10 @@ async fn test_readlink() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readlink:?}");
-    if matches!(readlink, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTSUPP, _))) {
-        tracing::info!("not supported by current implementation");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(readlink, Nfs3Result::Err((nfsstat3::NFS3ERR_NOTSUPP, _))),
+        "Expected NFS3ERR_NOTSUPP error"
+    );
 
     client.shutdown().await
 }
@@ -171,11 +172,10 @@ async fn test_read_dir_as_file() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{read:?}");
-    if matches!(read, Nfs3Result::Err((nfsstat3::NFS3ERR_ISDIR, _))) {
-        tracing::info!("not supported by current implementation");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(read, Nfs3Result::Err((nfsstat3::NFS3ERR_ISDIR, _))),
+        "Expected NFS3ERR_ISDIR error"
+    );
 
     client.shutdown().await
 }
@@ -245,9 +245,10 @@ async fn test_write() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{write:?}");
-    if !matches!(write, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(write, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -268,9 +269,10 @@ async fn test_create_unchecked() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{create:?}");
-    if !matches!(&create, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(create, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -291,9 +293,10 @@ async fn test_create_guarded() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{create:?}");
-    if !matches!(&create, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(create, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -314,9 +317,10 @@ async fn test_create_exclusive() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{create:?}");
-    if !matches!(&create, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(create, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -337,9 +341,10 @@ async fn test_mkdir() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{mkdir:?}");
-    if !matches!(&mkdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(mkdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -363,9 +368,10 @@ async fn test_symlink() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{symlink:?}");
-    if !matches!(symlink, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(symlink, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -388,11 +394,10 @@ async fn test_mknod() -> Result<(), anyhow::Error> {
         .await;
 
     tracing::info!("{mknod:?}");
-    if matches!(mknod, Err(Error::Rpc(RpcError::ProcUnavail))) {
-        tracing::info!("not supported by nfs3_server yet");
-    } else {
-        panic!("Expected NFS3ERR_NOTSUPP error");
-    }
+    assert!(
+        matches!(mknod, Err(Error::Rpc(RpcError::ProcUnavail))),
+        "Expected ProcUnavail error"
+    );
 
     client.shutdown().await
 }
@@ -412,9 +417,10 @@ async fn test_remove() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{remove:?}");
-    if !matches!(remove, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(remove, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
     client.shutdown().await
 }
 
@@ -433,9 +439,10 @@ async fn test_remove_noent() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{remove:?}");
-    if !matches!(remove, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(remove, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -455,9 +462,10 @@ async fn test_rmdir_noent() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rmdir:?}");
-    if !matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -477,9 +485,10 @@ async fn test_rmdir_notempty() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rmdir:?}");
-    if !matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -499,9 +508,10 @@ async fn test_rmdir() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rmdir:?}");
-    if !matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(rmdir, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -525,9 +535,10 @@ async fn test_rename() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{rename:?}");
-    if !matches!(rename, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))) {
-        panic!("Expected NFS3ERR_ROFS error");
-    }
+    assert!(
+        matches!(rename, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS error"
+    );
 
     client.shutdown().await
 }
@@ -549,11 +560,10 @@ async fn test_link() -> Result<(), anyhow::Error> {
         })
         .await;
 
-    if let Err(Error::Rpc(RpcError::ProcUnavail)) = link {
-        tracing::info!("Server does not support COMMIT yet");
-    } else {
-        panic!("Expected ProcUnavail error");
-    }
+    assert!(
+        matches!(link, Err(Error::Rpc(RpcError::ProcUnavail))),
+        "Expected ProcUnavail error"
+    );
 
     client.shutdown().await
 }
@@ -592,9 +602,10 @@ async fn test_readdir_too_small() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readdir:?}");
-    if !matches!(readdir, Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))) {
-        panic!("Expected NFS3ERR_TOOSMALL error");
-    }
+    assert!(
+        matches!(readdir, Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))),
+        "Expected NFS3ERR_TOOSMALL error"
+    );
 
     client.shutdown().await
 }
@@ -641,12 +652,13 @@ async fn test_readdirplus_dircount_too_small() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readdirplus:?}");
-    if !matches!(
-        readdirplus,
-        Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
-    ) {
-        panic!("Expected NFS3ERR_TOOSMALL error");
-    }
+    assert!(
+        matches!(
+            readdirplus,
+            Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
+        ),
+        "Expected NFS3ERR_TOOSMALL error"
+    );
 
     client.shutdown().await
 }
@@ -667,12 +679,13 @@ async fn test_readdirplus_maxcount_too_small() -> Result<(), anyhow::Error> {
         .await?;
 
     tracing::info!("{readdirplus:?}");
-    if !matches!(
-        readdirplus,
-        Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
-    ) {
-        panic!("Expected NFS3ERR_TOOSMALL error");
-    }
+    assert!(
+        matches!(
+            readdirplus,
+            Nfs3Result::Err((nfsstat3::NFS3ERR_TOOSMALL, _))
+        ),
+        "Expected NFS3ERR_TOOSMALL error"
+    );
 
     client.shutdown().await
 }
@@ -738,10 +751,11 @@ async fn test_commit() -> Result<(), anyhow::Error> {
         })
         .await?;
 
-    assert!(
-        matches!(commit, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
-        "Expected NFS3ERR_ROFS, got {commit:?}"
-    );
+    let Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, fail)) = commit else {
+        panic!("Expected NFS3ERR_ROFS, got {commit:?}");
+    };
+    let after_attr = fail.file_wcc.after.unwrap();
+    assert_eq!(after_attr.type_, ftype3::NF3DIR);
 
     client.shutdown().await
 }

--- a/crates/nfs3_tests/tests/ro_tests.rs
+++ b/crates/nfs3_tests/tests/ro_tests.rs
@@ -727,8 +727,6 @@ async fn test_pathconf() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_commit() -> Result<(), anyhow::Error> {
-    use nfs3_client::error::*;
-
     let mut client = TestContext::setup_ro();
     let root = client.root_dir().clone();
 
@@ -738,13 +736,12 @@ async fn test_commit() -> Result<(), anyhow::Error> {
             offset: 0,
             count: 1024,
         })
-        .await;
+        .await?;
 
-    if let Err(Error::Rpc(RpcError::ProcUnavail)) = commit {
-        tracing::info!("Server does not support COMMIT yet");
-    } else {
-        panic!("Expected ProcUnavail error");
-    }
+    assert!(
+        matches!(commit, Nfs3Result::Err((nfsstat3::NFS3ERR_ROFS, _))),
+        "Expected NFS3ERR_ROFS, got {commit:?}"
+    );
 
     client.shutdown().await
 }

--- a/crates/nfs3_types/src/nfs3.rs
+++ b/crates/nfs3_types/src/nfs3.rs
@@ -939,6 +939,16 @@ pub enum stable_how {
     FILE_SYNC = 2,
 }
 
+impl std::fmt::Display for stable_how {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::UNSTABLE => "UNSTABLE",
+            Self::DATA_SYNC => "DATA_SYNC",
+            Self::FILE_SYNC => "FILE_SYNC",
+        })
+    }
+}
+
 #[derive(Debug, XdrCodec)]
 pub struct symlinkdata3<'a> {
     pub symlink_attributes: sattr3,


### PR DESCRIPTION
This PR introduces breaking changes to the `NfsFileSystem` trait:

1. The `write` method signature changed in two ways:
   - A `stable: stable_how` parameter was added.
   - The return type changed from `Result<fattr3, nfsstat3>` to `Result<(fattr3, stable_how), nfsstat3>`.
2. New `commit` method

If your implementation doesn't need support for unstable writes, you can ignore the `stable` argument and always report `stable_how::FILE_SYNC`. In that case, the `commit` method can return `Ok(())` right away.

```rust
async fn write(
    &self, 
    id: &Self::Handle, 
    offset: u64, 
    data: &[u8], 
    _stable: stable_how)
-> Result<(fattr3, stable_how), nfsstat3> {
    // ... perform the write and flush to disk ...
    Ok((attr, stable_how::FILE_SYNC))
}

async fn commit(&self, _id: &Self::Handle, _offset: u64, _count: u32) -> Result<(), nfsstat3> {
    Ok(())
}
```
