### PR TITLE
feat(nfs3_client)!: split error type into more specific errors

### DIFF
--- a/crates/nfs3_client/examples/portmap.rs
+++ b/crates/nfs3_client/examples/portmap.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use nfs3_client::error::PortmapError;
+use nfs3_client::PortmapError;
 use nfs3_client::nfs3_types::mount::{PROGRAM as MOUNT_PROGRAM, VERSION as MOUNT_VERSION};
 use nfs3_client::nfs3_types::nfs3::{PROGRAM as NFS3_PROGRAM, VERSION as NFS3_VERSION};
 use nfs3_client::nfs3_types::portmap::PMAP_PORT;

--- a/crates/nfs3_client/examples/portmap.rs
+++ b/crates/nfs3_client/examples/portmap.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use nfs3_client::error::{Error, PortmapError};
+use nfs3_client::error::PortmapError;
 use nfs3_client::nfs3_types::mount::{PROGRAM as MOUNT_PROGRAM, VERSION as MOUNT_VERSION};
 use nfs3_client::nfs3_types::nfs3::{PROGRAM as NFS3_PROGRAM, VERSION as NFS3_VERSION};
 use nfs3_client::nfs3_types::portmap::PMAP_PORT;
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = portmapper.getport(MOUNT_PROGRAM, MOUNT_VERSION).await;
     match result {
         Ok(port) => println!("Resolved MOUNT3 port: {port}"),
-        Err(Error::Portmap(PortmapError::ProgramUnavailable)) => {
+        Err(PortmapError::ProgramUnavailable) => {
             eprintln!("MOUNT3 program is unavailable");
         }
         Err(e) => eprintln!("Failed to resolve MOUNT3 port: {e}"),
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = portmapper.getport(NFS3_PROGRAM, NFS3_VERSION).await;
     match result {
         Ok(port) => println!("Resolved NFSv3 port: {port}"),
-        Err(Error::Portmap(PortmapError::ProgramUnavailable)) => {
+        Err(PortmapError::ProgramUnavailable) => {
             eprintln!("NFSv3 program is unavailable");
         }
         Err(e) => eprintln!("Failed to resolve NFSv3 port: {e}"),

--- a/crates/nfs3_client/src/connect.rs
+++ b/crates/nfs3_client/src/connect.rs
@@ -8,9 +8,8 @@ use nfs3_types::nfs3::nfs_fh3;
 use nfs3_types::rpc::opaque_auth;
 use nfs3_types::xdr_codec::Opaque;
 
-use crate::error::{ConnectError, Error};
 use crate::io::{AsyncRead, AsyncWrite};
-use crate::{MountClient, Nfs3Client, mount, portmapper};
+use crate::{ConnectError, MountClient, Nfs3Client, RpcError, mount, portmapper};
 
 /// Contains the connection to the NFS server.
 #[derive(Debug)]
@@ -36,7 +35,7 @@ where
     }
 
     /// Unmounts the filesystem and drops the client.
-    pub async fn unmount(mut self) -> Result<(), Error> {
+    pub async fn unmount(mut self) -> Result<(), RpcError> {
         self.mount_client.umnt(self.mount_path).await
     }
 

--- a/crates/nfs3_client/src/connect.rs
+++ b/crates/nfs3_client/src/connect.rs
@@ -8,7 +8,7 @@ use nfs3_types::nfs3::nfs_fh3;
 use nfs3_types::rpc::opaque_auth;
 use nfs3_types::xdr_codec::Opaque;
 
-use crate::error::Error;
+use crate::error::{ConnectError, Error};
 use crate::io::{AsyncRead, AsyncWrite};
 use crate::{MountClient, Nfs3Client, mount, portmapper};
 
@@ -141,7 +141,7 @@ where
     }
 
     /// Mounts the filesystem and returns the connection.
-    pub async fn mount(self) -> Result<Nfs3Connection<S>, Error> {
+    pub async fn mount(self) -> Result<Nfs3Connection<S>, ConnectError> {
         let (mount_port, nfs3_port) = self.resolve_ports().await?;
 
         let io = self.connect(mount_port).await?;
@@ -164,7 +164,7 @@ where
         })
     }
 
-    async fn resolve_ports(&self) -> Result<(u16, u16), Error> {
+    async fn resolve_ports(&self) -> Result<(u16, u16), ConnectError> {
         if let (Some(mount_port), Some(nfs3_port)) = (self.mount_port, self.nfs3_port) {
             return Ok((mount_port, nfs3_port));
         }

--- a/crates/nfs3_client/src/error.rs
+++ b/crates/nfs3_client/src/error.rs
@@ -58,12 +58,12 @@ impl From<rejected_reply> for Error {
 pub enum RpcError {
     UnexpectedCall,
     Auth,
-    RpcMismatch,
+    RpcMismatch { low: u32, high: u32 },
     WrongLength,
     UnexpectedXid,
     NotFullyParsed { buf: Vec<u8>, pos: u64 },
     ProgUnavail,
-    ProgMismatch,
+    ProgMismatch { low: u32, high: u32 },
     ProcUnavail,
     GarbageArgs,
     SystemErr,
@@ -74,12 +74,16 @@ impl fmt::Display for RpcError {
         match self {
             Self::UnexpectedCall => write!(f, "Unexpected CALL request"),
             Self::Auth => write!(f, "Authentication error"),
-            Self::RpcMismatch => write!(f, "RPC version mismatch"),
+            Self::RpcMismatch { low, high } => {
+                write!(f, "RPC version mismatch (supported: {low}..={high})")
+            }
             Self::WrongLength => write!(f, "Wrong length in RPC message"),
             Self::UnexpectedXid => write!(f, "Unexpected XID in RPC reply"),
             Self::NotFullyParsed { .. } => write!(f, "Not fully parsed"),
             Self::ProgUnavail => write!(f, "Program unavailable"),
-            Self::ProgMismatch => write!(f, "Program mismatch"),
+            Self::ProgMismatch { low, high } => {
+                write!(f, "Program mismatch (supported: {low}..={high})")
+            }
             Self::ProcUnavail => write!(f, "Procedure unavailable"),
             Self::GarbageArgs => write!(f, "Garbage arguments"),
             Self::SystemErr => write!(f, "System error"),
@@ -92,7 +96,7 @@ impl StdError for RpcError {}
 impl From<rejected_reply> for RpcError {
     fn from(e: rejected_reply) -> Self {
         match e {
-            rejected_reply::RPC_MISMATCH { .. } => Self::RpcMismatch,
+            rejected_reply::RPC_MISMATCH { low, high } => Self::RpcMismatch { low, high },
             rejected_reply::AUTH_ERROR(_) => Self::Auth,
         }
     }
@@ -105,7 +109,7 @@ impl TryFrom<accept_stat_data> for RpcError {
         match value {
             accept_stat_data::SUCCESS => Err(()),
             accept_stat_data::PROG_UNAVAIL => Ok(Self::ProgUnavail),
-            accept_stat_data::PROG_MISMATCH { .. } => Ok(Self::ProgMismatch),
+            accept_stat_data::PROG_MISMATCH { low, high } => Ok(Self::ProgMismatch { low, high }),
             accept_stat_data::PROC_UNAVAIL => Ok(Self::ProcUnavail),
             accept_stat_data::GARBAGE_ARGS => Ok(Self::GarbageArgs),
             accept_stat_data::SYSTEM_ERR => Ok(Self::SystemErr),

--- a/crates/nfs3_client/src/error.rs
+++ b/crates/nfs3_client/src/error.rs
@@ -3,7 +3,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use nfs3_types::rpc::{accept_stat_data, rejected_reply};
+use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 
 #[derive(Debug)]
 pub enum Error {
@@ -22,8 +22,8 @@ impl fmt::Display for Error {
             Self::Xdr(e) => e.fmt(f),
             Self::Rpc(e) => e.fmt(f),
             Self::Portmap(e) => e.fmt(f),
-            Self::MountError(e) => (*e as u32).fmt(f),
-            Self::NfsError(e) => (*e as u32).fmt(f),
+            Self::MountError(e) => e.fmt(f),
+            Self::NfsError(e) => e.fmt(f),
         }
     }
 }
@@ -57,7 +57,7 @@ impl From<rejected_reply> for Error {
 #[derive(Debug)]
 pub enum RpcError {
     UnexpectedCall,
-    Auth,
+    Auth(auth_stat),
     RpcMismatch { low: u32, high: u32 },
     WrongLength,
     UnexpectedXid,
@@ -73,7 +73,7 @@ impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnexpectedCall => write!(f, "Unexpected CALL request"),
-            Self::Auth => write!(f, "Authentication error"),
+            Self::Auth(stat) => write!(f, "Authentication error: {stat}"),
             Self::RpcMismatch { low, high } => {
                 write!(f, "RPC version mismatch (supported: {low}..={high})")
             }
@@ -97,7 +97,7 @@ impl From<rejected_reply> for RpcError {
     fn from(e: rejected_reply) -> Self {
         match e {
             rejected_reply::RPC_MISMATCH { low, high } => Self::RpcMismatch { low, high },
-            rejected_reply::AUTH_ERROR(_) => Self::Auth,
+            rejected_reply::AUTH_ERROR(stat) => Self::Auth(stat),
         }
     }
 }

--- a/crates/nfs3_client/src/error/connect.rs
+++ b/crates/nfs3_client/src/error/connect.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::{MountError, PortmapError};
+use super::{MountError, PortmapError, RpcError};
 
 /// Error when establishing an NFS3 connection.
 ///
@@ -9,16 +9,22 @@ use super::{MountError, PortmapError};
 #[derive(Debug)]
 pub enum ConnectError {
     Io(std::io::Error),
-    Portmap(PortmapError),
-    Mount(MountError),
+    Xdr(nfs3_types::xdr_codec::Error),
+    Rpc(RpcError),
+    ProgramUnavailable,
+    InvalidPortValue(u32),
+    MountStatus(nfs3_types::mount::mountstat3),
 }
 
 impl fmt::Display for ConnectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(e) => e.fmt(f),
-            Self::Portmap(e) => e.fmt(f),
-            Self::Mount(e) => e.fmt(f),
+            Self::Xdr(e) => e.fmt(f),
+            Self::Rpc(e) => e.fmt(f),
+            Self::ProgramUnavailable => write!(f, "Program unavailable"),
+            Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
+            Self::MountStatus(e) => e.fmt(f),
         }
     }
 }
@@ -27,8 +33,9 @@ impl StdError for ConnectError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Self::Io(e) => Some(e),
-            Self::Portmap(e) => Some(e),
-            Self::Mount(e) => Some(e),
+            Self::Xdr(e) => Some(e),
+            Self::Rpc(e) => Some(e),
+            Self::ProgramUnavailable | Self::InvalidPortValue(_) | Self::MountStatus(_) => None,
         }
     }
 }
@@ -41,12 +48,23 @@ impl From<std::io::Error> for ConnectError {
 
 impl From<PortmapError> for ConnectError {
     fn from(e: PortmapError) -> Self {
-        Self::Portmap(e)
+        match e {
+            PortmapError::Io(e) => Self::Io(e),
+            PortmapError::Xdr(e) => Self::Xdr(e),
+            PortmapError::Rpc(e) => Self::Rpc(e),
+            PortmapError::ProgramUnavailable => Self::ProgramUnavailable,
+            PortmapError::InvalidPortValue(v) => Self::InvalidPortValue(v),
+        }
     }
 }
 
 impl From<MountError> for ConnectError {
     fn from(e: MountError) -> Self {
-        Self::Mount(e)
+        match e {
+            MountError::Io(e) => Self::Io(e),
+            MountError::Xdr(e) => Self::Xdr(e),
+            MountError::Rpc(e) => Self::Rpc(e),
+            MountError::Status(s) => Self::MountStatus(s),
+        }
     }
 }

--- a/crates/nfs3_client/src/error/connect.rs
+++ b/crates/nfs3_client/src/error/connect.rs
@@ -1,0 +1,52 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+use super::{MountError, PortmapError};
+
+/// Error when establishing an NFS3 connection.
+///
+/// Returned by [`Nfs3ConnectionBuilder::mount`](crate::Nfs3ConnectionBuilder::mount).
+#[derive(Debug)]
+pub enum ConnectError {
+    Io(std::io::Error),
+    Portmap(PortmapError),
+    Mount(MountError),
+}
+
+impl fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => e.fmt(f),
+            Self::Portmap(e) => e.fmt(f),
+            Self::Mount(e) => e.fmt(f),
+        }
+    }
+}
+
+impl StdError for ConnectError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Portmap(e) => Some(e),
+            Self::Mount(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for ConnectError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<PortmapError> for ConnectError {
+    fn from(e: PortmapError) -> Self {
+        Self::Portmap(e)
+    }
+}
+
+impl From<MountError> for ConnectError {
+    fn from(e: MountError) -> Self {
+        Self::Mount(e)
+    }
+}

--- a/crates/nfs3_client/src/error/connect.rs
+++ b/crates/nfs3_client/src/error/connect.rs
@@ -1,36 +1,27 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::{MountError, PortmapError, RpcError};
+use super::{MountError, PortmapError};
 
 /// Error when establishing an NFS3 connection.
 ///
 /// Returned by [`Nfs3ConnectionBuilder::mount`](crate::Nfs3ConnectionBuilder::mount).
 #[derive(Debug)]
 pub enum ConnectError {
-    /// An I/O error occurred during network communication.
+    /// An I/O error occurred when connecting to a port.
     Io(std::io::Error),
-    /// Failed to serialize or deserialize an XDR-encoded message.
-    Xdr(nfs3_types::xdr_codec::Error),
-    /// The RPC layer reported a protocol-level error.
-    Rpc(RpcError),
-    /// The requested program is not registered with the portmapper.
-    ProgramUnavailable,
-    /// The portmapper returned a port number that does not fit in a `u16`.
-    InvalidPortValue(u32),
-    /// The mount server denied the request with the given status code.
-    MountDenied(nfs3_types::mount::mountstat3),
+    /// A portmapper operation failed.
+    Portmap(PortmapError),
+    /// The mount operation failed.
+    Mount(MountError),
 }
 
 impl fmt::Display for ConnectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(e) => e.fmt(f),
-            Self::Xdr(e) => e.fmt(f),
-            Self::Rpc(e) => e.fmt(f),
-            Self::ProgramUnavailable => write!(f, "Program unavailable"),
-            Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
-            Self::MountDenied(e) => e.fmt(f),
+            Self::Portmap(e) => e.fmt(f),
+            Self::Mount(e) => e.fmt(f),
         }
     }
 }
@@ -39,9 +30,8 @@ impl StdError for ConnectError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Self::Io(e) => Some(e),
-            Self::Xdr(e) => Some(e),
-            Self::Rpc(e) => Some(e),
-            Self::ProgramUnavailable | Self::InvalidPortValue(_) | Self::MountDenied(_) => None,
+            Self::Portmap(e) => Some(e),
+            Self::Mount(e) => Some(e),
         }
     }
 }
@@ -54,23 +44,12 @@ impl From<std::io::Error> for ConnectError {
 
 impl From<PortmapError> for ConnectError {
     fn from(e: PortmapError) -> Self {
-        match e {
-            PortmapError::Io(e) => Self::Io(e),
-            PortmapError::Xdr(e) => Self::Xdr(e),
-            PortmapError::Rpc(e) => Self::Rpc(e),
-            PortmapError::ProgramUnavailable => Self::ProgramUnavailable,
-            PortmapError::InvalidPortValue(v) => Self::InvalidPortValue(v),
-        }
+        Self::Portmap(e)
     }
 }
 
 impl From<MountError> for ConnectError {
     fn from(e: MountError) -> Self {
-        match e {
-            MountError::Io(e) => Self::Io(e),
-            MountError::Xdr(e) => Self::Xdr(e),
-            MountError::Rpc(e) => Self::Rpc(e),
-            MountError::Denied(s) => Self::MountDenied(s),
-        }
+        Self::Mount(e)
     }
 }

--- a/crates/nfs3_client/src/error/connect.rs
+++ b/crates/nfs3_client/src/error/connect.rs
@@ -13,7 +13,7 @@ pub enum ConnectError {
     Rpc(RpcError),
     ProgramUnavailable,
     InvalidPortValue(u32),
-    MountStatus(nfs3_types::mount::mountstat3),
+    MountDenied(nfs3_types::mount::mountstat3),
 }
 
 impl fmt::Display for ConnectError {
@@ -24,7 +24,7 @@ impl fmt::Display for ConnectError {
             Self::Rpc(e) => e.fmt(f),
             Self::ProgramUnavailable => write!(f, "Program unavailable"),
             Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
-            Self::MountStatus(e) => e.fmt(f),
+            Self::MountDenied(e) => e.fmt(f),
         }
     }
 }
@@ -35,7 +35,7 @@ impl StdError for ConnectError {
             Self::Io(e) => Some(e),
             Self::Xdr(e) => Some(e),
             Self::Rpc(e) => Some(e),
-            Self::ProgramUnavailable | Self::InvalidPortValue(_) | Self::MountStatus(_) => None,
+            Self::ProgramUnavailable | Self::InvalidPortValue(_) | Self::MountDenied(_) => None,
         }
     }
 }
@@ -64,7 +64,7 @@ impl From<MountError> for ConnectError {
             MountError::Io(e) => Self::Io(e),
             MountError::Xdr(e) => Self::Xdr(e),
             MountError::Rpc(e) => Self::Rpc(e),
-            MountError::Status(s) => Self::MountStatus(s),
+            MountError::Denied(s) => Self::MountDenied(s),
         }
     }
 }

--- a/crates/nfs3_client/src/error/connect.rs
+++ b/crates/nfs3_client/src/error/connect.rs
@@ -8,11 +8,17 @@ use super::{MountError, PortmapError, RpcError};
 /// Returned by [`Nfs3ConnectionBuilder::mount`](crate::Nfs3ConnectionBuilder::mount).
 #[derive(Debug)]
 pub enum ConnectError {
+    /// An I/O error occurred during network communication.
     Io(std::io::Error),
+    /// Failed to serialize or deserialize an XDR-encoded message.
     Xdr(nfs3_types::xdr_codec::Error),
+    /// The RPC layer reported a protocol-level error.
     Rpc(RpcError),
+    /// The requested program is not registered with the portmapper.
     ProgramUnavailable,
+    /// The portmapper returned a port number that does not fit in a `u16`.
     InvalidPortValue(u32),
+    /// The mount server denied the request with the given status code.
     MountDenied(nfs3_types::mount::mountstat3),
 }
 

--- a/crates/nfs3_client/src/error/mod.rs
+++ b/crates/nfs3_client/src/error/mod.rs
@@ -5,7 +5,7 @@ mod mount;
 mod portmap;
 mod rpc;
 
-pub use connect::*;
-pub use mount::*;
-pub use portmap::*;
-pub use rpc::*;
+pub use connect::ConnectError;
+pub use mount::MountError;
+pub use portmap::PortmapError;
+pub use rpc::RpcError;

--- a/crates/nfs3_client/src/error/mod.rs
+++ b/crates/nfs3_client/src/error/mod.rs
@@ -1,0 +1,11 @@
+//! Error types
+
+mod connect;
+mod mount;
+mod portmap;
+mod rpc;
+
+pub use connect::*;
+pub use mount::*;
+pub use portmap::*;
+pub use rpc::*;

--- a/crates/nfs3_client/src/error/mount.rs
+++ b/crates/nfs3_client/src/error/mount.rs
@@ -1,18 +1,14 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::{Error, RpcError};
+use super::RpcError;
 
 /// Error from mount operations.
 ///
 /// Returned by [`MountClient::mnt`](crate::MountClient::mnt).
 #[derive(Debug)]
 pub enum MountError {
-    /// An I/O error occurred during network communication.
-    Io(std::io::Error),
-    /// Failed to serialize or deserialize an XDR-encoded message.
-    Xdr(nfs3_types::xdr_codec::Error),
-    /// The RPC layer reported a protocol-level error.
+    /// The RPC call failed.
     Rpc(RpcError),
     /// The mount server denied the request with the given status code.
     Denied(nfs3_types::mount::mountstat3),
@@ -21,8 +17,6 @@ pub enum MountError {
 impl fmt::Display for MountError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Io(e) => e.fmt(f),
-            Self::Xdr(e) => e.fmt(f),
             Self::Rpc(e) => e.fmt(f),
             Self::Denied(e) => e.fmt(f),
         }
@@ -32,20 +26,14 @@ impl fmt::Display for MountError {
 impl StdError for MountError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::Io(e) => Some(e),
-            Self::Xdr(e) => Some(e),
             Self::Rpc(e) => Some(e),
             Self::Denied(_) => None,
         }
     }
 }
 
-impl From<Error> for MountError {
-    fn from(e: Error) -> Self {
-        match e {
-            Error::Io(e) => Self::Io(e),
-            Error::Xdr(e) => Self::Xdr(e),
-            Error::Rpc(e) => Self::Rpc(e),
-        }
+impl From<RpcError> for MountError {
+    fn from(e: RpcError) -> Self {
+        Self::Rpc(e)
     }
 }

--- a/crates/nfs3_client/src/error/mount.rs
+++ b/crates/nfs3_client/src/error/mount.rs
@@ -11,7 +11,7 @@ pub enum MountError {
     Io(std::io::Error),
     Xdr(nfs3_types::xdr_codec::Error),
     Rpc(RpcError),
-    Status(nfs3_types::mount::mountstat3),
+    Denied(nfs3_types::mount::mountstat3),
 }
 
 impl fmt::Display for MountError {
@@ -20,7 +20,7 @@ impl fmt::Display for MountError {
             Self::Io(e) => e.fmt(f),
             Self::Xdr(e) => e.fmt(f),
             Self::Rpc(e) => e.fmt(f),
-            Self::Status(e) => e.fmt(f),
+            Self::Denied(e) => e.fmt(f),
         }
     }
 }
@@ -31,7 +31,7 @@ impl StdError for MountError {
             Self::Io(e) => Some(e),
             Self::Xdr(e) => Some(e),
             Self::Rpc(e) => Some(e),
-            Self::Status(_) => None,
+            Self::Denied(_) => None,
         }
     }
 }

--- a/crates/nfs3_client/src/error/mount.rs
+++ b/crates/nfs3_client/src/error/mount.rs
@@ -1,0 +1,37 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+use super::Error;
+
+/// Error from mount operations.
+///
+/// Returned by [`MountClient::mnt`](crate::MountClient::mnt).
+#[derive(Debug)]
+pub enum MountError {
+    Call(Error),
+    Status(nfs3_types::mount::mountstat3),
+}
+
+impl fmt::Display for MountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Call(e) => e.fmt(f),
+            Self::Status(e) => e.fmt(f),
+        }
+    }
+}
+
+impl StdError for MountError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Call(e) => Some(e),
+            Self::Status(_) => None,
+        }
+    }
+}
+
+impl From<Error> for MountError {
+    fn from(e: Error) -> Self {
+        Self::Call(e)
+    }
+}

--- a/crates/nfs3_client/src/error/mount.rs
+++ b/crates/nfs3_client/src/error/mount.rs
@@ -1,21 +1,25 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::Error;
+use super::{Error, RpcError};
 
 /// Error from mount operations.
 ///
 /// Returned by [`MountClient::mnt`](crate::MountClient::mnt).
 #[derive(Debug)]
 pub enum MountError {
-    Call(Error),
+    Io(std::io::Error),
+    Xdr(nfs3_types::xdr_codec::Error),
+    Rpc(RpcError),
     Status(nfs3_types::mount::mountstat3),
 }
 
 impl fmt::Display for MountError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Call(e) => e.fmt(f),
+            Self::Io(e) => e.fmt(f),
+            Self::Xdr(e) => e.fmt(f),
+            Self::Rpc(e) => e.fmt(f),
             Self::Status(e) => e.fmt(f),
         }
     }
@@ -24,7 +28,9 @@ impl fmt::Display for MountError {
 impl StdError for MountError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::Call(e) => Some(e),
+            Self::Io(e) => Some(e),
+            Self::Xdr(e) => Some(e),
+            Self::Rpc(e) => Some(e),
             Self::Status(_) => None,
         }
     }
@@ -32,6 +38,10 @@ impl StdError for MountError {
 
 impl From<Error> for MountError {
     fn from(e: Error) -> Self {
-        Self::Call(e)
+        match e {
+            Error::Io(e) => Self::Io(e),
+            Error::Xdr(e) => Self::Xdr(e),
+            Error::Rpc(e) => Self::Rpc(e),
+        }
     }
 }

--- a/crates/nfs3_client/src/error/mount.rs
+++ b/crates/nfs3_client/src/error/mount.rs
@@ -8,9 +8,13 @@ use super::{Error, RpcError};
 /// Returned by [`MountClient::mnt`](crate::MountClient::mnt).
 #[derive(Debug)]
 pub enum MountError {
+    /// An I/O error occurred during network communication.
     Io(std::io::Error),
+    /// Failed to serialize or deserialize an XDR-encoded message.
     Xdr(nfs3_types::xdr_codec::Error),
+    /// The RPC layer reported a protocol-level error.
     Rpc(RpcError),
+    /// The mount server denied the request with the given status code.
     Denied(nfs3_types::mount::mountstat3),
 }
 

--- a/crates/nfs3_client/src/error/portmap.rs
+++ b/crates/nfs3_client/src/error/portmap.rs
@@ -8,10 +8,15 @@ use super::{Error, RpcError};
 /// Returned by [`PortmapperClient::getport`](crate::PortmapperClient::getport).
 #[derive(Debug)]
 pub enum PortmapError {
+    /// An I/O error occurred during network communication.
     Io(std::io::Error),
+    /// Failed to serialize or deserialize an XDR-encoded message.
     Xdr(nfs3_types::xdr_codec::Error),
+    /// The RPC layer reported a protocol-level error.
     Rpc(RpcError),
+    /// The requested program is not registered with the portmapper.
     ProgramUnavailable,
+    /// The portmapper returned a port number that does not fit in a `u16`.
     InvalidPortValue(u32),
 }
 

--- a/crates/nfs3_client/src/error/portmap.rs
+++ b/crates/nfs3_client/src/error/portmap.rs
@@ -1,14 +1,16 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::Error;
+use super::{Error, RpcError};
 
 /// Error from portmapper operations.
 ///
 /// Returned by [`PortmapperClient::getport`](crate::PortmapperClient::getport).
 #[derive(Debug)]
 pub enum PortmapError {
-    Call(Error),
+    Io(std::io::Error),
+    Xdr(nfs3_types::xdr_codec::Error),
+    Rpc(RpcError),
     ProgramUnavailable,
     InvalidPortValue(u32),
 }
@@ -16,7 +18,9 @@ pub enum PortmapError {
 impl fmt::Display for PortmapError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Call(e) => e.fmt(f),
+            Self::Io(e) => e.fmt(f),
+            Self::Xdr(e) => e.fmt(f),
+            Self::Rpc(e) => e.fmt(f),
             Self::ProgramUnavailable => write!(f, "Program unavailable"),
             Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
         }
@@ -26,7 +30,9 @@ impl fmt::Display for PortmapError {
 impl StdError for PortmapError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::Call(e) => Some(e),
+            Self::Io(e) => Some(e),
+            Self::Xdr(e) => Some(e),
+            Self::Rpc(e) => Some(e),
             Self::ProgramUnavailable | Self::InvalidPortValue(_) => None,
         }
     }
@@ -34,6 +40,10 @@ impl StdError for PortmapError {
 
 impl From<Error> for PortmapError {
     fn from(e: Error) -> Self {
-        Self::Call(e)
+        match e {
+            Error::Io(e) => Self::Io(e),
+            Error::Xdr(e) => Self::Xdr(e),
+            Error::Rpc(e) => Self::Rpc(e),
+        }
     }
 }

--- a/crates/nfs3_client/src/error/portmap.rs
+++ b/crates/nfs3_client/src/error/portmap.rs
@@ -1,18 +1,14 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-use super::{Error, RpcError};
+use super::RpcError;
 
 /// Error from portmapper operations.
 ///
 /// Returned by [`PortmapperClient::getport`](crate::PortmapperClient::getport).
 #[derive(Debug)]
 pub enum PortmapError {
-    /// An I/O error occurred during network communication.
-    Io(std::io::Error),
-    /// Failed to serialize or deserialize an XDR-encoded message.
-    Xdr(nfs3_types::xdr_codec::Error),
-    /// The RPC layer reported a protocol-level error.
+    /// The RPC call failed.
     Rpc(RpcError),
     /// The requested program is not registered with the portmapper.
     ProgramUnavailable,
@@ -23,8 +19,6 @@ pub enum PortmapError {
 impl fmt::Display for PortmapError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Io(e) => e.fmt(f),
-            Self::Xdr(e) => e.fmt(f),
             Self::Rpc(e) => e.fmt(f),
             Self::ProgramUnavailable => write!(f, "Program unavailable"),
             Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
@@ -35,20 +29,14 @@ impl fmt::Display for PortmapError {
 impl StdError for PortmapError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::Io(e) => Some(e),
-            Self::Xdr(e) => Some(e),
             Self::Rpc(e) => Some(e),
             Self::ProgramUnavailable | Self::InvalidPortValue(_) => None,
         }
     }
 }
 
-impl From<Error> for PortmapError {
-    fn from(e: Error) -> Self {
-        match e {
-            Error::Io(e) => Self::Io(e),
-            Error::Xdr(e) => Self::Xdr(e),
-            Error::Rpc(e) => Self::Rpc(e),
-        }
+impl From<RpcError> for PortmapError {
+    fn from(e: RpcError) -> Self {
+        Self::Rpc(e)
     }
 }

--- a/crates/nfs3_client/src/error/portmap.rs
+++ b/crates/nfs3_client/src/error/portmap.rs
@@ -1,0 +1,39 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+use super::Error;
+
+/// Error from portmapper operations.
+///
+/// Returned by [`PortmapperClient::getport`](crate::PortmapperClient::getport).
+#[derive(Debug)]
+pub enum PortmapError {
+    Call(Error),
+    ProgramUnavailable,
+    InvalidPortValue(u32),
+}
+
+impl fmt::Display for PortmapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Call(e) => e.fmt(f),
+            Self::ProgramUnavailable => write!(f, "Program unavailable"),
+            Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
+        }
+    }
+}
+
+impl StdError for PortmapError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Call(e) => Some(e),
+            Self::ProgramUnavailable | Self::InvalidPortValue(_) => None,
+        }
+    }
+}
+
+impl From<Error> for PortmapError {
+    fn from(e: Error) -> Self {
+        Self::Call(e)
+    }
+}

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -10,8 +10,11 @@ use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 /// operations.
 #[derive(Debug)]
 pub enum Error {
+    /// An I/O error occurred during network communication.
     Io(std::io::Error),
+    /// Failed to serialize or deserialize an XDR-encoded message.
     Xdr(nfs3_types::xdr_codec::Error),
+    /// The RPC layer reported a protocol-level error.
     Rpc(RpcError),
 }
 

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -3,9 +3,6 @@ use std::fmt;
 
 use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 
-/// Backward-compatible alias for [`RpcError`].
-pub type Error = RpcError;
-
 /// Error from an RPC call.
 ///
 /// Covers I/O failures, XDR encoding/decoding issues, and RPC protocol errors.

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -1,18 +1,18 @@
-//! Error types
-
 use std::error::Error as StdError;
 use std::fmt;
 
 use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 
+/// RPC transport error.
+///
+/// Returned by methods that only perform RPC calls, such as
+/// [`RpcClient::call`](crate::rpc::RpcClient::call) and all [`Nfs3Client`](crate::Nfs3Client)
+/// operations.
 #[derive(Debug)]
 pub enum Error {
     Io(std::io::Error),
     Xdr(nfs3_types::xdr_codec::Error),
     Rpc(RpcError),
-    Portmap(PortmapError),
-    MountError(nfs3_types::mount::mountstat3),
-    NfsError(nfs3_types::nfs3::nfsstat3),
 }
 
 impl fmt::Display for Error {
@@ -21,14 +21,19 @@ impl fmt::Display for Error {
             Self::Io(e) => e.fmt(f),
             Self::Xdr(e) => e.fmt(f),
             Self::Rpc(e) => e.fmt(f),
-            Self::Portmap(e) => e.fmt(f),
-            Self::MountError(e) => e.fmt(f),
-            Self::NfsError(e) => e.fmt(f),
         }
     }
 }
 
-impl StdError for Error {}
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Xdr(e) => Some(e),
+            Self::Rpc(e) => Some(e),
+        }
+    }
+}
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
@@ -114,28 +119,5 @@ impl TryFrom<accept_stat_data> for RpcError {
             accept_stat_data::GARBAGE_ARGS => Ok(Self::GarbageArgs),
             accept_stat_data::SYSTEM_ERR => Ok(Self::SystemErr),
         }
-    }
-}
-
-#[derive(Debug)]
-pub enum PortmapError {
-    ProgramUnavailable,
-    InvalidPortValue(u32),
-}
-
-impl fmt::Display for PortmapError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ProgramUnavailable => write!(f, "Program unavailable"),
-            Self::InvalidPortValue(value) => write!(f, "Invalid port value: {value}"),
-        }
-    }
-}
-
-impl StdError for PortmapError {}
-
-impl From<PortmapError> for Error {
-    fn from(e: PortmapError) -> Self {
-        Self::Portmap(e)
     }
 }

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -49,6 +49,12 @@ pub enum RpcError {
     ProcUnavail,
     /// The server could not decode the procedure arguments.
     GarbageArgs,
+    /// The server sent a fragmented reply, which is not supported.
+    ///
+    /// Handling fragmented replies would require significant changes to the
+    /// receive logic because subsequent fragments are not guaranteed to arrive
+    /// immediately after the first one.
+    FragmentedReply,
     /// An unspecified server-side system error occurred.
     SystemErr,
 }
@@ -72,6 +78,7 @@ impl fmt::Display for RpcError {
             }
             Self::ProcUnavail => write!(f, "Procedure unavailable"),
             Self::GarbageArgs => write!(f, "Garbage arguments"),
+            Self::FragmentedReply => write!(f, "Fragmented replies are not supported"),
             Self::SystemErr => write!(f, "System error"),
         }
     }

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -3,11 +3,11 @@ use std::fmt;
 
 use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 
-/// RPC transport error.
+/// Error from an RPC call.
 ///
-/// Returned by methods that only perform RPC calls, such as
-/// [`RpcClient::call`](crate::rpc::RpcClient::call) and all [`Nfs3Client`](crate::Nfs3Client)
-/// operations.
+/// Covers I/O failures, XDR encoding/decoding issues, and RPC protocol errors.
+/// Returned by [`RpcClient::call`](crate::rpc::RpcClient::call) and all
+/// [`Nfs3Client`](crate::Nfs3Client) operations.
 #[derive(Debug)]
 pub enum Error {
     /// An I/O error occurred during network communication.

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -59,18 +59,49 @@ impl From<rejected_reply> for Error {
     }
 }
 
+/// RPC protocol error.
+///
+/// These errors originate from the RPC layer itself, either locally detected
+/// (e.g. wrong XID) or reported by the server in its reply
+/// (e.g. [`AUTH_ERROR`](rejected_reply::AUTH_ERROR), [`PROG_MISMATCH`](accept_stat_data::PROG_MISMATCH)).
 #[derive(Debug)]
 pub enum RpcError {
+    /// Received a CALL message when a REPLY was expected.
     UnexpectedCall,
+    /// Server rejected the request due to an authentication failure.
     Auth(auth_stat),
-    RpcMismatch { low: u32, high: u32 },
+    /// Server does not support the requested RPC version.
+    RpcMismatch {
+        /// Lowest supported RPC version.
+        low: u32,
+        /// Highest supported RPC version.
+        high: u32,
+    },
+    /// The serialized RPC message length is not a multiple of 4 bytes.
     WrongLength,
+    /// The reply XID does not match the request XID.
     UnexpectedXid,
-    NotFullyParsed { buf: Vec<u8>, pos: u64 },
+    /// The reply was not fully consumed after decoding.
+    NotFullyParsed {
+        /// Raw reply buffer.
+        buf: Vec<u8>,
+        /// Cursor position where parsing stopped.
+        pos: u64,
+    },
+    /// The requested program is not available on the server.
     ProgUnavail,
-    ProgMismatch { low: u32, high: u32 },
+    /// The requested program version is not supported.
+    ProgMismatch {
+        /// Lowest supported program version.
+        low: u32,
+        /// Highest supported program version.
+        high: u32,
+    },
+    /// The requested procedure is not available.
     ProcUnavail,
+    /// The server could not decode the procedure arguments.
     GarbageArgs,
+    /// An unspecified server-side system error occurred.
     SystemErr,
 }
 

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -3,72 +3,20 @@ use std::fmt;
 
 use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 
+/// Backward-compatible alias for [`RpcError`].
+pub type Error = RpcError;
+
 /// Error from an RPC call.
 ///
 /// Covers I/O failures, XDR encoding/decoding issues, and RPC protocol errors.
 /// Returned by [`RpcClient::call`](crate::rpc::RpcClient::call) and all
 /// [`Nfs3Client`](crate::Nfs3Client) operations.
 #[derive(Debug)]
-pub enum Error {
+pub enum RpcError {
     /// An I/O error occurred during network communication.
     Io(std::io::Error),
     /// Failed to serialize or deserialize an XDR-encoded message.
     Xdr(nfs3_types::xdr_codec::Error),
-    /// The RPC layer reported a protocol-level error.
-    Rpc(RpcError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(e) => e.fmt(f),
-            Self::Xdr(e) => e.fmt(f),
-            Self::Rpc(e) => e.fmt(f),
-        }
-    }
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::Io(e) => Some(e),
-            Self::Xdr(e) => Some(e),
-            Self::Rpc(e) => Some(e),
-        }
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self {
-        Self::Io(e)
-    }
-}
-
-impl From<nfs3_types::xdr_codec::Error> for Error {
-    fn from(e: nfs3_types::xdr_codec::Error) -> Self {
-        Self::Xdr(e)
-    }
-}
-
-impl From<RpcError> for Error {
-    fn from(e: RpcError) -> Self {
-        Self::Rpc(e)
-    }
-}
-
-impl From<rejected_reply> for Error {
-    fn from(e: rejected_reply) -> Self {
-        Self::Rpc(e.into())
-    }
-}
-
-/// RPC protocol error.
-///
-/// These errors originate from the RPC layer itself, either locally detected
-/// (e.g. wrong XID) or reported by the server in its reply
-/// (e.g. [`AUTH_ERROR`](rejected_reply::AUTH_ERROR), [`PROG_MISMATCH`](accept_stat_data::PROG_MISMATCH)).
-#[derive(Debug)]
-pub enum RpcError {
     /// Received a CALL message when a REPLY was expected.
     UnexpectedCall,
     /// Server rejected the request due to an authentication failure.
@@ -111,6 +59,8 @@ pub enum RpcError {
 impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Io(e) => e.fmt(f),
+            Self::Xdr(e) => e.fmt(f),
             Self::UnexpectedCall => write!(f, "Unexpected CALL request"),
             Self::Auth(stat) => write!(f, "Authentication error: {stat}"),
             Self::RpcMismatch { low, high } => {
@@ -130,7 +80,27 @@ impl fmt::Display for RpcError {
     }
 }
 
-impl StdError for RpcError {}
+impl StdError for RpcError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Xdr(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for RpcError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<nfs3_types::xdr_codec::Error> for RpcError {
+    fn from(e: nfs3_types::xdr_codec::Error) -> Self {
+        Self::Xdr(e)
+    }
+}
 
 impl From<rejected_reply> for RpcError {
     fn from(e: rejected_reply) -> Self {

--- a/crates/nfs3_client/src/lib.rs
+++ b/crates/nfs3_client/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc = include_str!("../README.md")]
 
 pub(crate) mod connect;
-pub mod error;
+mod error;
 pub mod io;
 pub(crate) mod mount;
 pub mod net;
@@ -19,6 +19,7 @@ pub mod tokio;
 pub mod smol;
 
 pub use connect::*;
+pub use error::{ConnectError, MountError, PortmapError, RpcError};
 pub use mount::*;
 pub use nfs::*;
 /// Re-export of `nfs3_types` for convenience

--- a/crates/nfs3_client/src/mount.rs
+++ b/crates/nfs3_client/src/mount.rs
@@ -43,14 +43,17 @@ where
         Ok(())
     }
 
-    pub async fn mnt(&mut self, dirpath_: dirpath<'_>) -> Result<mountres3_ok<'static>, Error> {
+    pub async fn mnt(
+        &mut self,
+        dirpath_: dirpath<'_>,
+    ) -> Result<mountres3_ok<'static>, crate::error::MountError> {
         let result = self
             .call::<dirpath, mountres3>(MOUNT_PROGRAM::MOUNTPROC3_MNT, dirpath_)
             .await?;
 
         match result {
             mountres3::Ok(ok) => Ok(ok),
-            mountres3::Err(err) => Err(Error::MountError(err)),
+            mountres3::Err(err) => Err(crate::error::MountError::Status(err)),
         }
     }
 

--- a/crates/nfs3_client/src/mount.rs
+++ b/crates/nfs3_client/src/mount.rs
@@ -53,7 +53,7 @@ where
 
         match result {
             mountres3::Ok(ok) => Ok(ok),
-            mountres3::Err(err) => Err(crate::error::MountError::Status(err)),
+            mountres3::Err(err) => Err(crate::error::MountError::Denied(err)),
         }
     }
 

--- a/crates/nfs3_client/src/mount.rs
+++ b/crates/nfs3_client/src/mount.rs
@@ -4,7 +4,7 @@ use nfs3_types::mount::{
 use nfs3_types::rpc::opaque_auth;
 use nfs3_types::xdr_codec::{Pack, Unpack, Void};
 
-use crate::error::Error;
+use crate::error::{MountError, RpcError};
 use crate::io::{AsyncRead, AsyncWrite};
 use crate::rpc::RpcClient;
 
@@ -36,7 +36,7 @@ where
         }
     }
 
-    pub async fn null(&mut self) -> Result<(), Error> {
+    pub async fn null(&mut self) -> Result<(), RpcError> {
         let _ = self
             .call::<Void, Void>(MOUNT_PROGRAM::MOUNTPROC3_NULL, Void)
             .await?;
@@ -46,42 +46,42 @@ where
     pub async fn mnt(
         &mut self,
         dirpath_: dirpath<'_>,
-    ) -> Result<mountres3_ok<'static>, crate::error::MountError> {
+    ) -> Result<mountres3_ok<'static>, MountError> {
         let result = self
             .call::<dirpath, mountres3>(MOUNT_PROGRAM::MOUNTPROC3_MNT, dirpath_)
             .await?;
 
         match result {
             mountres3::Ok(ok) => Ok(ok),
-            mountres3::Err(err) => Err(crate::error::MountError::Denied(err)),
+            mountres3::Err(err) => Err(MountError::Denied(err)),
         }
     }
 
-    pub async fn dump(&mut self) -> Result<mountlist<'static, 'static>, Error> {
+    pub async fn dump(&mut self) -> Result<mountlist<'static, 'static>, RpcError> {
         self.call::<Void, mountlist>(MOUNT_PROGRAM::MOUNTPROC3_DUMP, Void)
             .await
     }
 
-    pub async fn umnt(&mut self, dirpath_: dirpath<'_>) -> Result<(), Error> {
+    pub async fn umnt(&mut self, dirpath_: dirpath<'_>) -> Result<(), RpcError> {
         let _ = self
             .call::<dirpath, Void>(MOUNT_PROGRAM::MOUNTPROC3_UMNT, dirpath_)
             .await?;
         Ok(())
     }
 
-    pub async fn umntall(&mut self) -> Result<(), Error> {
+    pub async fn umntall(&mut self) -> Result<(), RpcError> {
         let _ = self
             .call::<Void, Void>(MOUNT_PROGRAM::MOUNTPROC3_UMNTALL, Void)
             .await?;
         Ok(())
     }
 
-    pub async fn export(&mut self) -> Result<exports<'static, 'static>, Error> {
+    pub async fn export(&mut self) -> Result<exports<'static, 'static>, RpcError> {
         self.call::<Void, exports>(MOUNT_PROGRAM::MOUNTPROC3_EXPORT, Void)
             .await
     }
 
-    async fn call<C, R>(&mut self, proc: MOUNT_PROGRAM, args: C) -> Result<R, crate::error::Error>
+    async fn call<C, R>(&mut self, proc: MOUNT_PROGRAM, args: C) -> Result<R, RpcError>
     where
         R: Unpack,
         C: Pack + Send + Sync,

--- a/crates/nfs3_client/src/nfs.rs
+++ b/crates/nfs3_client/src/nfs.rs
@@ -10,7 +10,7 @@ use nfs3_types::nfs3::{
 use nfs3_types::rpc::opaque_auth;
 use nfs3_types::xdr_codec::{Pack, Unpack, Void};
 
-use crate::error::Error;
+use crate::RpcError;
 use crate::io::{AsyncRead, AsyncWrite};
 use crate::rpc::RpcClient;
 
@@ -42,89 +42,92 @@ where
         }
     }
 
-    pub async fn null(&mut self) -> Result<(), Error> {
+    pub async fn null(&mut self) -> Result<(), RpcError> {
         let _ = self
             .call::<Void, Void>(NFS_PROGRAM::NFSPROC3_NULL, &Void)
             .await?;
         Ok(())
     }
 
-    pub async fn getattr(&mut self, args: &GETATTR3args) -> Result<GETATTR3res, Error> {
+    pub async fn getattr(&mut self, args: &GETATTR3args) -> Result<GETATTR3res, RpcError> {
         self.call::<GETATTR3args, GETATTR3res>(NFS_PROGRAM::NFSPROC3_GETATTR, args)
             .await
     }
 
-    pub async fn setattr(&mut self, args: &SETATTR3args) -> Result<SETATTR3res, Error> {
+    pub async fn setattr(&mut self, args: &SETATTR3args) -> Result<SETATTR3res, RpcError> {
         self.call::<SETATTR3args, SETATTR3res>(NFS_PROGRAM::NFSPROC3_SETATTR, args)
             .await
     }
 
-    pub async fn lookup(&mut self, args: &LOOKUP3args<'_>) -> Result<LOOKUP3res, Error> {
+    pub async fn lookup(&mut self, args: &LOOKUP3args<'_>) -> Result<LOOKUP3res, RpcError> {
         self.call::<LOOKUP3args, LOOKUP3res>(NFS_PROGRAM::NFSPROC3_LOOKUP, args)
             .await
     }
 
-    pub async fn access(&mut self, args: &ACCESS3args) -> Result<ACCESS3res, Error> {
+    pub async fn access(&mut self, args: &ACCESS3args) -> Result<ACCESS3res, RpcError> {
         self.call::<ACCESS3args, ACCESS3res>(NFS_PROGRAM::NFSPROC3_ACCESS, args)
             .await
     }
 
-    pub async fn readlink(&mut self, args: &READLINK3args) -> Result<READLINK3res<'static>, Error> {
+    pub async fn readlink(
+        &mut self,
+        args: &READLINK3args,
+    ) -> Result<READLINK3res<'static>, RpcError> {
         self.call::<READLINK3args, READLINK3res>(NFS_PROGRAM::NFSPROC3_READLINK, args)
             .await
     }
 
-    pub async fn read(&mut self, args: &READ3args) -> Result<READ3res<'static>, Error> {
+    pub async fn read(&mut self, args: &READ3args) -> Result<READ3res<'static>, RpcError> {
         self.call::<READ3args, READ3res>(NFS_PROGRAM::NFSPROC3_READ, args)
             .await
     }
 
-    pub async fn write(&mut self, args: &WRITE3args<'_>) -> Result<WRITE3res, Error> {
+    pub async fn write(&mut self, args: &WRITE3args<'_>) -> Result<WRITE3res, RpcError> {
         self.call::<WRITE3args, WRITE3res>(NFS_PROGRAM::NFSPROC3_WRITE, args)
             .await
     }
 
-    pub async fn create(&mut self, args: &CREATE3args<'_>) -> Result<CREATE3res, Error> {
+    pub async fn create(&mut self, args: &CREATE3args<'_>) -> Result<CREATE3res, RpcError> {
         self.call::<CREATE3args, CREATE3res>(NFS_PROGRAM::NFSPROC3_CREATE, args)
             .await
     }
 
-    pub async fn mkdir(&mut self, args: &MKDIR3args<'_>) -> Result<MKDIR3res, Error> {
+    pub async fn mkdir(&mut self, args: &MKDIR3args<'_>) -> Result<MKDIR3res, RpcError> {
         self.call::<MKDIR3args, MKDIR3res>(NFS_PROGRAM::NFSPROC3_MKDIR, args)
             .await
     }
 
-    pub async fn symlink(&mut self, args: &SYMLINK3args<'_>) -> Result<SYMLINK3res, Error> {
+    pub async fn symlink(&mut self, args: &SYMLINK3args<'_>) -> Result<SYMLINK3res, RpcError> {
         self.call::<SYMLINK3args, SYMLINK3res>(NFS_PROGRAM::NFSPROC3_SYMLINK, args)
             .await
     }
 
-    pub async fn mknod(&mut self, args: &MKNOD3args<'_>) -> Result<MKNOD3res, Error> {
+    pub async fn mknod(&mut self, args: &MKNOD3args<'_>) -> Result<MKNOD3res, RpcError> {
         self.call::<MKNOD3args, MKNOD3res>(NFS_PROGRAM::NFSPROC3_MKNOD, args)
             .await
     }
 
-    pub async fn remove(&mut self, args: &REMOVE3args<'_>) -> Result<REMOVE3res, Error> {
+    pub async fn remove(&mut self, args: &REMOVE3args<'_>) -> Result<REMOVE3res, RpcError> {
         self.call::<REMOVE3args, REMOVE3res>(NFS_PROGRAM::NFSPROC3_REMOVE, args)
             .await
     }
 
-    pub async fn rmdir(&mut self, args: &RMDIR3args<'_>) -> Result<RMDIR3res, Error> {
+    pub async fn rmdir(&mut self, args: &RMDIR3args<'_>) -> Result<RMDIR3res, RpcError> {
         self.call::<RMDIR3args, RMDIR3res>(NFS_PROGRAM::NFSPROC3_RMDIR, args)
             .await
     }
 
-    pub async fn rename(&mut self, args: &RENAME3args<'_, '_>) -> Result<RENAME3res, Error> {
+    pub async fn rename(&mut self, args: &RENAME3args<'_, '_>) -> Result<RENAME3res, RpcError> {
         self.call::<RENAME3args, RENAME3res>(NFS_PROGRAM::NFSPROC3_RENAME, args)
             .await
     }
 
-    pub async fn link(&mut self, args: &LINK3args<'_>) -> Result<LINK3res, Error> {
+    pub async fn link(&mut self, args: &LINK3args<'_>) -> Result<LINK3res, RpcError> {
         self.call::<LINK3args, LINK3res>(NFS_PROGRAM::NFSPROC3_LINK, args)
             .await
     }
 
-    pub async fn readdir(&mut self, args: &READDIR3args) -> Result<READDIR3res<'static>, Error> {
+    pub async fn readdir(&mut self, args: &READDIR3args) -> Result<READDIR3res<'static>, RpcError> {
         self.call::<READDIR3args, READDIR3res>(NFS_PROGRAM::NFSPROC3_READDIR, args)
             .await
     }
@@ -132,32 +135,32 @@ where
     pub async fn readdirplus(
         &mut self,
         args: &READDIRPLUS3args,
-    ) -> Result<READDIRPLUS3res<'static>, Error> {
+    ) -> Result<READDIRPLUS3res<'static>, RpcError> {
         self.call::<READDIRPLUS3args, READDIRPLUS3res>(NFS_PROGRAM::NFSPROC3_READDIRPLUS, args)
             .await
     }
 
-    pub async fn fsstat(&mut self, args: &FSSTAT3args) -> Result<FSSTAT3res, Error> {
+    pub async fn fsstat(&mut self, args: &FSSTAT3args) -> Result<FSSTAT3res, RpcError> {
         self.call::<FSSTAT3args, FSSTAT3res>(NFS_PROGRAM::NFSPROC3_FSSTAT, args)
             .await
     }
 
-    pub async fn fsinfo(&mut self, args: &FSINFO3args) -> Result<FSINFO3res, Error> {
+    pub async fn fsinfo(&mut self, args: &FSINFO3args) -> Result<FSINFO3res, RpcError> {
         self.call::<FSINFO3args, FSINFO3res>(NFS_PROGRAM::NFSPROC3_FSINFO, args)
             .await
     }
 
-    pub async fn pathconf(&mut self, args: &PATHCONF3args) -> Result<PATHCONF3res, Error> {
+    pub async fn pathconf(&mut self, args: &PATHCONF3args) -> Result<PATHCONF3res, RpcError> {
         self.call::<PATHCONF3args, PATHCONF3res>(NFS_PROGRAM::NFSPROC3_PATHCONF, args)
             .await
     }
 
-    pub async fn commit(&mut self, args: &COMMIT3args) -> Result<COMMIT3res, Error> {
+    pub async fn commit(&mut self, args: &COMMIT3args) -> Result<COMMIT3res, RpcError> {
         self.call::<COMMIT3args, COMMIT3res>(NFS_PROGRAM::NFSPROC3_COMMIT, args)
             .await
     }
 
-    async fn call<C, R>(&mut self, proc: NFS_PROGRAM, args: &C) -> Result<R, crate::error::Error>
+    async fn call<C, R>(&mut self, proc: NFS_PROGRAM, args: &C) -> Result<R, RpcError>
     where
         R: Unpack,
         C: Pack + Send + Sync,

--- a/crates/nfs3_client/src/portmapper.rs
+++ b/crates/nfs3_client/src/portmapper.rs
@@ -1,6 +1,8 @@
 use nfs3_types::portmap::{PMAP_PROG, PROGRAM, VERSION, mapping, pmaplist};
 use nfs3_types::xdr_codec::{Pack, Unpack, Void};
 
+use crate::RpcError;
+use crate::error::PortmapError;
 use crate::io::{AsyncRead, AsyncWrite};
 use crate::rpc::RpcClient;
 
@@ -20,18 +22,14 @@ where
         }
     }
 
-    pub async fn null(&mut self) -> Result<(), crate::error::Error> {
+    pub async fn null(&mut self) -> Result<(), RpcError> {
         let _ = self
             .call::<Void, Void>(PMAP_PROG::PMAPPROC_NULL, Void)
             .await?;
         Ok(())
     }
 
-    pub async fn getport(
-        &mut self,
-        prog: u32,
-        vers: u32,
-    ) -> Result<u16, crate::error::PortmapError> {
+    pub async fn getport(&mut self, prog: u32, vers: u32) -> Result<u16, PortmapError> {
         let args = mapping {
             prog,
             vers,
@@ -45,20 +43,20 @@ where
 
         let port_u16: Result<u16, _> = port.try_into();
         match port_u16 {
-            Ok(0) => Err(crate::error::PortmapError::ProgramUnavailable),
+            Ok(0) => Err(PortmapError::ProgramUnavailable),
             Ok(port) => Ok(port),
-            Err(_) => Err(crate::error::PortmapError::InvalidPortValue(port)),
+            Err(_) => Err(PortmapError::InvalidPortValue(port)),
         }
     }
 
-    pub async fn dump(&mut self) -> Result<Vec<mapping>, crate::error::Error> {
+    pub async fn dump(&mut self) -> Result<Vec<mapping>, RpcError> {
         let mappings = self
             .call::<Void, pmaplist>(PMAP_PROG::PMAPPROC_DUMP, Void)
             .await?;
         Ok(mappings.into_inner())
     }
 
-    async fn call<C, R>(&mut self, proc: PMAP_PROG, args: C) -> Result<R, crate::error::Error>
+    async fn call<C, R>(&mut self, proc: PMAP_PROG, args: C) -> Result<R, RpcError>
     where
         R: Unpack,
         C: Pack + Send + Sync,

--- a/crates/nfs3_client/src/portmapper.rs
+++ b/crates/nfs3_client/src/portmapper.rs
@@ -27,7 +27,11 @@ where
         Ok(())
     }
 
-    pub async fn getport(&mut self, prog: u32, vers: u32) -> Result<u16, crate::error::Error> {
+    pub async fn getport(
+        &mut self,
+        prog: u32,
+        vers: u32,
+    ) -> Result<u16, crate::error::PortmapError> {
         let args = mapping {
             prog,
             vers,
@@ -41,9 +45,9 @@ where
 
         let port_u16: Result<u16, _> = port.try_into();
         match port_u16 {
-            Ok(0) => Err(crate::error::PortmapError::ProgramUnavailable.into()),
+            Ok(0) => Err(crate::error::PortmapError::ProgramUnavailable),
             Ok(port) => Ok(port),
-            Err(_) => Err(crate::error::PortmapError::InvalidPortValue(port).into()),
+            Err(_) => Err(crate::error::PortmapError::InvalidPortValue(port)),
         }
     }
 

--- a/crates/nfs3_client/src/rpc.rs
+++ b/crates/nfs3_client/src/rpc.rs
@@ -8,7 +8,7 @@ use nfs3_types::rpc::{
 };
 use nfs3_types::xdr_codec::{Pack, Unpack};
 
-use crate::error::{Error, RpcError};
+use crate::RpcError;
 use crate::io::{AsyncRead, AsyncWrite};
 
 /// RPC client
@@ -59,7 +59,7 @@ where
         vers: u32,
         proc: u32,
         args: &C,
-    ) -> Result<R, Error>
+    ) -> Result<R, RpcError>
     where
         R: Unpack,
         C: Pack + Send + Sync,
@@ -82,7 +82,7 @@ where
         Self::recv_reply::<R>(&mut self.io, msg.xid).await
     }
 
-    async fn send_call<T>(io: &mut IO, msg: &rpc_msg<'_, '_>, args: &T) -> Result<(), Error>
+    async fn send_call<T>(io: &mut IO, msg: &rpc_msg<'_, '_>, args: &T) -> Result<(), RpcError>
     where
         T: Pack + Send + Sync,
     {
@@ -106,7 +106,7 @@ where
         Ok(())
     }
 
-    async fn recv_reply<T>(io: &mut IO, xid: u32) -> Result<T, Error>
+    async fn recv_reply<T>(io: &mut IO, xid: u32) -> Result<T, RpcError>
     where
         T: Unpack,
     {
@@ -131,12 +131,12 @@ where
 
         let reply = match resp_msg.body {
             msg_body::REPLY(reply_body::MSG_ACCEPTED(reply)) => reply,
-            msg_body::REPLY(reply_body::MSG_DENIED(r)) => return Err(r.into()),
+            msg_body::REPLY(reply_body::MSG_DENIED(r)) => return Err(RpcError::from(r)),
             msg_body::CALL(_) => return Err(RpcError::UnexpectedCall),
         };
 
         if !matches!(reply.reply_data, accept_stat_data::SUCCESS) {
-            return Err(crate::error::RpcError::try_from(reply.reply_data)
+            return Err(RpcError::try_from(reply.reply_data)
                 .expect("accept_stat_data::SUCCESS is not a valid error"));
         }
 

--- a/crates/nfs3_client/src/rpc.rs
+++ b/crates/nfs3_client/src/rpc.rs
@@ -88,7 +88,7 @@ where
     {
         let total_len = msg.packed_size() + args.packed_size();
         if !total_len.is_multiple_of(4) {
-            return Err(RpcError::WrongLength.into());
+            return Err(RpcError::WrongLength);
         }
 
         let fragment_header = nfs3_types::rpc::fragment_header::new(
@@ -100,7 +100,7 @@ where
         msg.pack(&mut buf)?;
         args.pack(&mut buf)?;
         if buf.len() - 4 != total_len {
-            return Err(RpcError::WrongLength.into());
+            return Err(RpcError::WrongLength);
         }
         io.async_write_all(&buf).await?;
         Ok(())
@@ -126,19 +126,18 @@ where
         let (resp_msg, _) = rpc_msg::unpack(&mut cursor)?;
 
         if resp_msg.xid != xid {
-            return Err(RpcError::UnexpectedXid.into());
+            return Err(RpcError::UnexpectedXid);
         }
 
         let reply = match resp_msg.body {
             msg_body::REPLY(reply_body::MSG_ACCEPTED(reply)) => reply,
             msg_body::REPLY(reply_body::MSG_DENIED(r)) => return Err(r.into()),
-            msg_body::CALL(_) => return Err(RpcError::UnexpectedCall.into()),
+            msg_body::CALL(_) => return Err(RpcError::UnexpectedCall),
         };
 
         if !matches!(reply.reply_data, accept_stat_data::SUCCESS) {
             return Err(crate::error::RpcError::try_from(reply.reply_data)
-                .expect("accept_stat_data::SUCCESS is not a valid error")
-                .into());
+                .expect("accept_stat_data::SUCCESS is not a valid error"));
         }
 
         let (final_value, _) = T::unpack(&mut cursor)?;
@@ -147,8 +146,7 @@ where
             return Err(RpcError::NotFullyParsed {
                 buf: cursor.into_inner(),
                 pos,
-            }
-            .into());
+            });
         }
         Ok(final_value)
     }

--- a/crates/nfs3_client/src/rpc.rs
+++ b/crates/nfs3_client/src/rpc.rs
@@ -113,10 +113,9 @@ where
         let mut buf = [0u8; 4];
         io.async_read_exact(&mut buf).await?;
         let fragment_header: fragment_header = buf.into();
-        assert!(
-            fragment_header.eof(),
-            "Fragment header does not have EOF flag"
-        );
+        if !fragment_header.eof() {
+            return Err(RpcError::FragmentedReply);
+        }
 
         let total_len = fragment_header.fragment_length();
         let mut buf = vec![0u8; total_len as usize];

--- a/crates/nfs3_tests/src/bin/test_mirror_fs/readonly.rs
+++ b/crates/nfs3_tests/src/bin/test_mirror_fs/readonly.rs
@@ -860,7 +860,7 @@ pub async fn mknod_readonly_error(ctx: &mut TestContext, _subdir: PathBuf, subdi
         .await;
 
     match mknod_result {
-        Err(nfs3_client::error::RpcError::ProcUnavail) => {}
+        Err(nfs3_client::RpcError::ProcUnavail) => {}
         _ => panic!(
             "Expected RpcError::ProcUnavail error for mknod on readonly filesystem, got: \
              {mknod_result:?}"
@@ -993,7 +993,7 @@ pub async fn link_readonly_error(ctx: &mut TestContext, subdir: PathBuf, subdir_
         .await;
 
     match link_result {
-        Err(nfs3_client::error::RpcError::ProcUnavail) => {}
+        Err(nfs3_client::RpcError::ProcUnavail) => {}
         _ => panic!(
             "Expected RpcError::ProcUnavail error for link on readonly filesystem, got: \
              {link_result:?}"

--- a/crates/nfs3_tests/src/bin/test_mirror_fs/readonly.rs
+++ b/crates/nfs3_tests/src/bin/test_mirror_fs/readonly.rs
@@ -860,7 +860,7 @@ pub async fn mknod_readonly_error(ctx: &mut TestContext, _subdir: PathBuf, subdi
         .await;
 
     match mknod_result {
-        Err(nfs3_client::error::Error::Rpc(nfs3_client::error::RpcError::ProcUnavail)) => {}
+        Err(nfs3_client::error::RpcError::ProcUnavail) => {}
         _ => panic!(
             "Expected RpcError::ProcUnavail error for mknod on readonly filesystem, got: \
              {mknod_result:?}"
@@ -993,7 +993,7 @@ pub async fn link_readonly_error(ctx: &mut TestContext, subdir: PathBuf, subdir_
         .await;
 
     match link_result {
-        Err(nfs3_client::error::Error::Rpc(nfs3_client::error::RpcError::ProcUnavail)) => {}
+        Err(nfs3_client::error::RpcError::ProcUnavail) => {}
         _ => panic!(
             "Expected RpcError::ProcUnavail error for link on readonly filesystem, got: \
              {link_result:?}"

--- a/crates/nfs3_tests/tests/base_tests.rs
+++ b/crates/nfs3_tests/tests/base_tests.rs
@@ -373,7 +373,7 @@ async fn test_symlink() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_mknod() -> Result<(), anyhow::Error> {
-    use nfs3_client::error::*;
+    use nfs3_client::RpcError;
 
     let mut client = TestContext::setup();
     let root = client.root_dir().clone();
@@ -390,7 +390,7 @@ async fn test_mknod() -> Result<(), anyhow::Error> {
 
     tracing::info!("{mknod:?}");
     assert!(
-        matches!(mknod, Err(Error::ProcUnavail)),
+        matches!(mknod, Err(RpcError::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 
@@ -517,7 +517,7 @@ async fn test_rmdir() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_link() -> Result<(), anyhow::Error> {
-    use nfs3_client::error::*;
+    use nfs3_client::RpcError;
 
     let mut client = TestContext::setup();
     let root = client.root_dir().clone();
@@ -533,7 +533,7 @@ async fn test_link() -> Result<(), anyhow::Error> {
         .await;
 
     assert!(
-        matches!(link, Err(Error::ProcUnavail)),
+        matches!(link, Err(RpcError::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 

--- a/crates/nfs3_tests/tests/base_tests.rs
+++ b/crates/nfs3_tests/tests/base_tests.rs
@@ -390,7 +390,7 @@ async fn test_mknod() -> Result<(), anyhow::Error> {
 
     tracing::info!("{mknod:?}");
     assert!(
-        matches!(mknod, Err(Error::Rpc(RpcError::ProcUnavail))),
+        matches!(mknod, Err(Error::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 
@@ -533,7 +533,7 @@ async fn test_link() -> Result<(), anyhow::Error> {
         .await;
 
     assert!(
-        matches!(link, Err(Error::Rpc(RpcError::ProcUnavail))),
+        matches!(link, Err(Error::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 

--- a/crates/nfs3_tests/tests/ro_tests.rs
+++ b/crates/nfs3_tests/tests/ro_tests.rs
@@ -395,7 +395,7 @@ async fn test_mknod() -> Result<(), anyhow::Error> {
 
     tracing::info!("{mknod:?}");
     assert!(
-        matches!(mknod, Err(Error::Rpc(RpcError::ProcUnavail))),
+        matches!(mknod, Err(Error::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 
@@ -561,7 +561,7 @@ async fn test_link() -> Result<(), anyhow::Error> {
         .await;
 
     assert!(
-        matches!(link, Err(Error::Rpc(RpcError::ProcUnavail))),
+        matches!(link, Err(Error::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 

--- a/crates/nfs3_tests/tests/ro_tests.rs
+++ b/crates/nfs3_tests/tests/ro_tests.rs
@@ -395,7 +395,7 @@ async fn test_mknod() -> Result<(), anyhow::Error> {
 
     tracing::info!("{mknod:?}");
     assert!(
-        matches!(mknod, Err(Error::ProcUnavail)),
+        matches!(mknod, Err(RpcError::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 
@@ -545,8 +545,6 @@ async fn test_rename() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_link() -> Result<(), anyhow::Error> {
-    use nfs3_client::error::*;
-
     let mut client = TestContext::setup_ro();
     let root = client.root_dir().clone();
 
@@ -561,7 +559,7 @@ async fn test_link() -> Result<(), anyhow::Error> {
         .await;
 
     assert!(
-        matches!(link, Err(Error::ProcUnavail)),
+        matches!(link, Err(RpcError::ProcUnavail)),
         "Expected ProcUnavail error"
     );
 

--- a/crates/nfs3_tests/tests/ro_tests.rs
+++ b/crates/nfs3_tests/tests/ro_tests.rs
@@ -378,7 +378,7 @@ async fn test_symlink() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_mknod() -> Result<(), anyhow::Error> {
-    use nfs3_client::error::*;
+    use nfs3_client::RpcError;
 
     let mut client = TestContext::setup_ro();
     let root = client.root_dir().clone();
@@ -545,6 +545,8 @@ async fn test_rename() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_link() -> Result<(), anyhow::Error> {
+    use nfs3_client::RpcError;
+
     let mut client = TestContext::setup_ro();
     let root = client.root_dir().clone();
 

--- a/crates/nfs3_types/src/rpc.rs
+++ b/crates/nfs3_types/src/rpc.rs
@@ -106,6 +106,22 @@ pub enum auth_stat {
     AUTH_FAILED = 7,
 }
 
+impl std::fmt::Display for auth_stat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::AUTH_OK => "AUTH_OK",
+            Self::AUTH_BADCRED => "AUTH_BADCRED",
+            Self::AUTH_REJECTEDCRED => "AUTH_REJECTEDCRED",
+            Self::AUTH_BADVERF => "AUTH_BADVERF",
+            Self::AUTH_REJECTEDVERF => "AUTH_REJECTEDVERF",
+            Self::AUTH_TOOWEAK => "AUTH_TOOWEAK",
+            Self::AUTH_INVALIDRESP => "AUTH_INVALIDRESP",
+            Self::AUTH_FAILED => "AUTH_FAILED",
+        };
+        write!(f, "{name}")
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, XdrCodec)]
 #[repr(u32)]
 pub enum auth_flavor {


### PR DESCRIPTION
Replace the monolithic `Error` enum in `nfs3_client` with purpose-specific error types. Each public API surface now returns a precise error type instead of a catch-all.

## New error type hierarchy

| Type | Used by |
|------|---------|
| `RpcError` | `RpcClient::call`, all `Nfs3Client` operations |
| `PortmapError` | `PortmapperClient::getport` |
| `MountError` | `MountClient::mnt` |
| `ConnectError` | `Nfs3ConnectionBuilder::mount` | 

## Error detail preservation

- `Auth` now carries the `auth_stat` value instead of discarding it
- `RpcMismatch` and `ProgMismatch` now carry `{ low, high }` version bounds
- return `RpcError::FragmentedReply` instead of panicing
- All error types implement `Display`, `Debug`, and `std::error::Error` with proper `source()` chains
