### PR TITLE
feat(nfs3_client): add is_connection_reusable method to error types

### DIFF
--- a/crates/nfs3_client/src/error/connect.rs
+++ b/crates/nfs3_client/src/error/connect.rs
@@ -53,3 +53,16 @@ impl From<MountError> for ConnectError {
         Self::Mount(e)
     }
 }
+
+impl ConnectError {
+    /// Returns `true` if the connection that produced this error is still in
+    /// a clean state and may be reused.
+    #[must_use]
+    pub const fn is_connection_reusable(&self) -> bool {
+        match self {
+            Self::Io(_) => false,
+            Self::Portmap(e) => e.is_connection_reusable(),
+            Self::Mount(e) => e.is_connection_reusable(),
+        }
+    }
+}

--- a/crates/nfs3_client/src/error/mount.rs
+++ b/crates/nfs3_client/src/error/mount.rs
@@ -37,3 +37,15 @@ impl From<RpcError> for MountError {
         Self::Rpc(e)
     }
 }
+
+impl MountError {
+    /// Returns `true` if the connection that produced this error is still in
+    /// a clean state and may be reused.
+    #[must_use]
+    pub const fn is_connection_reusable(&self) -> bool {
+        match self {
+            Self::Rpc(e) => e.is_connection_reusable(),
+            Self::Denied(_) => true,
+        }
+    }
+}

--- a/crates/nfs3_client/src/error/portmap.rs
+++ b/crates/nfs3_client/src/error/portmap.rs
@@ -40,3 +40,15 @@ impl From<RpcError> for PortmapError {
         Self::Rpc(e)
     }
 }
+
+impl PortmapError {
+    /// Returns `true` if the connection that produced this error is still in
+    /// a clean state and may be reused.
+    #[must_use]
+    pub const fn is_connection_reusable(&self) -> bool {
+        match self {
+            Self::Rpc(e) => e.is_connection_reusable(),
+            Self::ProgramUnavailable | Self::InvalidPortValue(_) => true,
+        }
+    }
+}

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -139,11 +139,19 @@ impl TryFrom<accept_stat_data> for RpcError {
 impl RpcError {
     /// Returns `true` if the connection that produced this error is still in
     /// a clean state and may be reused for the next call.
+    ///
+    /// Returns `false` only for [`Io`](Self::Io) (transport is dead) and
+    /// [`FragmentedReply`](Self::FragmentedReply) (unread fragment data left
+    /// in the socket).
+    ///
+    /// All other errors — including [`Xdr`](Self::Xdr),
+    /// [`WrongLength`](Self::WrongLength), [`NotFullyParsed`](Self::NotFullyParsed),
+    /// and [`UnexpectedXid`](Self::UnexpectedXid) — are produced while
+    /// operating on in-memory buffers after the full fragment has already been
+    /// consumed from the wire, so the transport remains at a clean message
+    /// boundary.
     #[must_use]
     pub const fn is_connection_reusable(&self) -> bool {
-        !matches!(
-            self,
-            Self::Io(_) | Self::Xdr(_) | Self::WrongLength | Self::FragmentedReply
-        )
+        !matches!(self, Self::Io(_) | Self::FragmentedReply)
     }
 }

--- a/crates/nfs3_client/src/error/rpc.rs
+++ b/crates/nfs3_client/src/error/rpc.rs
@@ -8,6 +8,12 @@ use nfs3_types::rpc::{accept_stat_data, auth_stat, rejected_reply};
 /// Covers I/O failures, XDR encoding/decoding issues, and RPC protocol errors.
 /// Returned by [`RpcClient::call`](crate::rpc::RpcClient::call) and all
 /// [`Nfs3Client`](crate::Nfs3Client) operations.
+///
+/// # Connection state after an error
+///
+/// Not every error leaves the underlying transport in the same state.
+/// Use [`is_connection_reusable`](Self::is_connection_reusable) to decide
+/// whether the connection can be kept.
 #[derive(Debug)]
 pub enum RpcError {
     /// An I/O error occurred during network communication.
@@ -127,5 +133,17 @@ impl TryFrom<accept_stat_data> for RpcError {
             accept_stat_data::GARBAGE_ARGS => Ok(Self::GarbageArgs),
             accept_stat_data::SYSTEM_ERR => Ok(Self::SystemErr),
         }
+    }
+}
+
+impl RpcError {
+    /// Returns `true` if the connection that produced this error is still in
+    /// a clean state and may be reused for the next call.
+    #[must_use]
+    pub const fn is_connection_reusable(&self) -> bool {
+        !matches!(
+            self,
+            Self::Io(_) | Self::Xdr(_) | Self::WrongLength | Self::FragmentedReply
+        )
     }
 }

--- a/crates/nfs3_client/src/rpc.rs
+++ b/crates/nfs3_client/src/rpc.rs
@@ -58,7 +58,7 @@ where
     /// connection can be kept.
     #[expect(
         clippy::similar_names,
-        reason = "prog and proc are parts of call_body struct"
+        reason = "prog and proc are fields of call_body"
     )]
     pub async fn call<C, R>(
         &mut self,

--- a/crates/nfs3_client/src/rpc.rs
+++ b/crates/nfs3_client/src/rpc.rs
@@ -50,9 +50,16 @@ where
 
     /// Call an RPC procedure
     ///
-    /// This method uses `Pack` trait to serialize the arguments and `Unpack` trait to deserialize
-    /// the reply.
-    #[allow(clippy::similar_names)] // prog and proc are part of call_body struct
+    /// # Errors and connection state
+    ///
+    /// On a successful return the connection is in a clean state and may be
+    /// reused for the next call. When an error is returned, use
+    /// [`RpcError::is_connection_reusable`] to decide whether the
+    /// connection can be kept.
+    #[expect(
+        clippy::similar_names,
+        reason = "prog and proc are parts of call_body struct"
+    )]
     pub async fn call<C, R>(
         &mut self,
         prog: u32,


### PR DESCRIPTION
Adds an `is_connection_reusable` method to all error types in nfs3_client, letting callers decide whether a connection can be kept after an error without inspecting individual variants